### PR TITLE
Add policy replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ otherwise you will get a 404 error during invocation.
 Applies a file-based YAML to a named policy. This method only
 supports additive changes.
 
+#### `replace_policy_file(policy_name, policy_file)`
+
+Replaces a named policy with one from the provided file. This is
+usually a destructive invocation.
+
 
 ## Contributing
 

--- a/conjur_api_python3/api.py
+++ b/conjur_api_python3/api.py
@@ -177,3 +177,22 @@ class Api():
         return invoke_endpoint(HttpVerb.POST, ConjurEndpoint.POLICIES, params,
                                policy_data, api_token=self.api_token,
                                ssl_verify=self._ssl_verify).text
+
+    def replace_policy_file(self, policy_id, policy_file):
+        """
+        This method is used to replace a file-based policy into the desired
+        policy ID.
+        """
+
+        params = {
+            'identifier': policy_id,
+        }
+        params.update(self._default_params)
+
+        policy_data = None
+        with open(policy_file, 'r') as content_file:
+            policy_data = content_file.read()
+
+        return invoke_endpoint(HttpVerb.PUT, ConjurEndpoint.POLICIES, params,
+                               policy_data, api_token=self.api_token,
+                               ssl_verify=self._ssl_verify).text

--- a/conjur_api_python3/cli.py
+++ b/conjur_api_python3/cli.py
@@ -60,6 +60,13 @@ class Cli():
         apply_policy_parser.add_argument('policy',
             help='File containing the YAML policy')
 
+        replace_policy_parser = policy_subparsers.add_parser('replace',
+            help='Replace a policy file')
+        replace_policy_parser.add_argument('name',
+            help='Name of the policy (usually "root")')
+        replace_policy_parser.add_argument('policy',
+            help='File containing the YAML policy')
+
 
         parser.add_argument('-v', '--version', action='version',
             version='%(prog)s v' + __version__)
@@ -126,8 +133,12 @@ class Cli():
             else:
                 client.set(variable_id, args.value)
                 print("Value set: '{}'".format(variable_id))
-        elif resource == 'policy' and args.action == 'apply':
-            client.apply_policy_file(args.name, args.policy)
+        elif resource == 'policy':
+            if args.action == 'replace':
+                client.replace_policy_file(args.name, args.policy)
+            else:
+                client.apply_policy_file(args.name, args.policy)
+
 
     @staticmethod
     def _parse_args(parser):

--- a/conjur_api_python3/client.py
+++ b/conjur_api_python3/client.py
@@ -110,3 +110,9 @@ class Client():
         Applies a file-based policy to the Conjur instance
         """
         self._api.apply_policy_file(policy_name, policy_file)
+
+    def replace_policy_file(self, policy_name, policy_file):
+        """
+        Replaces a file-based policy defined in the Conjur instance
+        """
+        self._api.replace_policy_file(policy_name, policy_file)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -134,6 +134,8 @@ class ApiTest(unittest.TestCase):
                               login='mylogin',
                               ssl_verify='verify')
 
+    # Get variable
+
     @patch('conjur_api_python3.api.invoke_endpoint', return_value=MockClientResponse())
     def test_get_variable_invokes_http_client_correctly(self, mock_http_client):
         api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
@@ -162,6 +164,8 @@ class ApiTest(unittest.TestCase):
                               kind='variable',
                               identifier='myvar',
                               ssl_verify='verify')
+
+    # Set variable
 
     @patch('conjur_api_python3.api.invoke_endpoint', return_value=MockClientResponse())
     def test_set_variable_invokes_http_client_correctly(self, mock_http_client):
@@ -193,6 +197,8 @@ class ApiTest(unittest.TestCase):
                               kind='variable',
                               identifier='myvar',
                               ssl_verify='verify')
+
+    # Policy apply
 
     @patch('conjur_api_python3.api.invoke_endpoint', return_value=MockClientResponse())
     def test_apply_policy_invokes_http_client_correctly(self, mock_http_client):
@@ -226,6 +232,44 @@ class ApiTest(unittest.TestCase):
             policy_data = content_file.read()
 
         self.verify_http_call(mock_http_client, HttpVerb.POST, ConjurEndpoint.POLICIES,
+                              policy_data,
+                              identifier='mypolicyname',
+                              ssl_verify='ssl_verify')
+
+    # Policy replace
+
+    @patch('conjur_api_python3.api.invoke_endpoint', return_value=MockClientResponse())
+    def test_replace_policy_invokes_http_client_correctly(self, mock_http_client):
+        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        def mock_auth():
+            return 'apitoken'
+        api.authenticate = mock_auth
+
+        api.replace_policy_file('mypolicyname', self.POLICY_FILE)
+
+        policy_data = None
+        with open(self.POLICY_FILE, 'r') as content_file:
+            policy_data = content_file.read()
+
+        self.verify_http_call(mock_http_client, HttpVerb.PUT, ConjurEndpoint.POLICIES,
+                              policy_data,
+                              identifier='mypolicyname',
+                              ssl_verify=True)
+
+    @patch('conjur_api_python3.api.invoke_endpoint', return_value=MockClientResponse())
+    def test_replace_policy_passes_down_ssl_verify_parameter(self, mock_http_client):
+        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey', ssl_verify='ssl_verify')
+        def mock_auth():
+            return 'apitoken'
+        api.authenticate = mock_auth
+
+        api.replace_policy_file('mypolicyname', self.POLICY_FILE)
+
+        policy_data = None
+        with open(self.POLICY_FILE, 'r') as content_file:
+            policy_data = content_file.read()
+
+        self.verify_http_call(mock_http_client, HttpVerb.PUT, ConjurEndpoint.POLICIES,
                               policy_data,
                               identifier='mypolicyname',
                               ssl_verify='ssl_verify')

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -36,3 +36,7 @@ class CliTest(unittest.TestCase):
     @cli_test(["policy", "apply", "foo", "foopolicy"])
     def test_cli_invokes_policy_apply_correctly(self, cli_invocation, output, client):
         client.apply_policy_file.assert_called_once_with('foo', 'foopolicy')
+
+    @cli_test(["policy", "replace", "foo", "foopolicy"])
+    def test_cli_invokes_policy_replace_correctly(self, cli_invocation, output, client):
+        client.replace_policy_file.assert_called_once_with('foo', 'foopolicy')

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -162,3 +162,12 @@ class ClientTest(unittest.TestCase):
         Client(api_class=MockApi, api_config_class=MockApiConfig).apply_policy_file('name', 'policy')
 
         MockApi.apply_policy_file.assert_called_once_with('name', 'policy')
+
+    def test_client_passes_through_api_replace_policy_params(self):
+        class MockApi(MockApiHelper):
+            pass
+        MockApi.replace_policy_file = MagicMock()
+
+        Client(api_class=MockApi, api_config_class=MockApiConfig).replace_policy_file('name', 'policy')
+
+        MockApi.replace_policy_file.assert_called_once_with('name', 'policy')


### PR DESCRIPTION
This adds the ability to replace a policy defined in Conjur in both the API and CLI