### PR TITLE
Fix upstream CVE-2019-11324 issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ pylint>=2.3.1
 PyInstaller>=3.4
 PyYAML>=3.13
 requests>=2.21.0
+
+# https://github.com/kennethreitz/requests/issues/5065
+urllib3>=1.24.2,<1.25


### PR DESCRIPTION
Urllib3 had CVE-2019-11324 that `requests` uses so we now pin for the
fixed version to ensure we don't get the faulty dependency.

https://github.com/kennethreitz/requests/issues/5065