### PR TITLE
14 - Fix conjurrc empty value overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ The first tagged version.
 
 [Unreleased]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.2...HEAD
 [0.0.2]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.1...0.0.2
+[0.0.1]: https://github.com/cyberark/conjur-api-python3/tree/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed application of conjurrc overrides of `Client` initialization params [#14](https://github.com/cyberark/conjur-api-python3/issues/14)
+
 ## [0.0.2] - 2019-05-17
 
 ### Changed

--- a/conjur/client.py
+++ b/conjur/client.py
@@ -70,12 +70,14 @@ class Client():
                 on_disk_config = dict(api_config_class())
 
                 # We want to retain any overrides that the user provided from params
-                on_disk_config.update(config)
+                # but only if those values are valid
+                for field_name, field_value in config.items():
+                    if field_value:
+                        on_disk_config[field_name] = field_value
                 config = on_disk_config
 
             except Exception as exc:
                 raise ConfigException(exc)
-
 
         if api_key:
             logging.info("Using API key from parameters...")

--- a/conjur/version.py
+++ b/conjur/version.py
@@ -7,4 +7,4 @@ This module contains the version information about the project that
 is intended to be reused in multiple places.
 """
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -17,6 +17,8 @@ class MockApiConfig(object):
         'url': 'apiconfigurl',
         'account': 'apiconfigaccount',
         'ca_bundle': 'apiconfigcabundle',
+        'login_id': 'apiconfigloginid',
+        'api_key': 'apiconfigapikey',
     }
 
     def __iter__(self):
@@ -142,6 +144,20 @@ class ClientTest(unittest.TestCase):
 
         Client(api_class=MockApi, api_config_class=MockApiConfig, url='http://foo',
                account='myacct', login_id='mylogin', ca_bundle='mybundle')
+
+    def test_client_does_not_override_apiconfig_values_with_empty_values(self):
+        class MockApi(MockApiHelper):
+            def verify_init_args(api_instance, **kwargs):
+                api_instance.verify_apiconfig_dict_in(self, **kwargs)
+                self.assertEqual(kwargs['account'], 'apiconfigaccount')
+                self.assertEqual(kwargs['url'], 'apiconfigurl')
+                self.assertEqual(kwargs['ca_bundle'], 'apiconfigcabundle')
+                self.assertEqual(kwargs['login_id'], 'apiconfigloginid')
+                self.assertEqual(kwargs['api_key'], 'apiconfigapikey')
+
+        Client(api_class=MockApi, api_config_class=MockApiConfig, url=None,
+               account=None, login_id=None, ca_bundle=None)
+
 
     ### API passthrough tests ###
 


### PR DESCRIPTION
Fixes #14 

We now properly override `None` values in `Client` initialization with the ones from conjurrc.

CC: @AndrewCopeland