### PR TITLE
Fix conjurrc account parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.4]
+
+### Fixed
+
+- Fixed overrides handling of `Client` account param [#21](https://github.com/cyberark/conjur-api-python3/issues/21)
+- Fixed running of linter due to `cryptography` upstream bug
+- Fixed failing tests when running on different OS YAML parsing libraries
+
 ## [0.0.3]
 
 ### Fixed
@@ -26,7 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 The first tagged version.
 
-[Unreleased]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.3...HEAD
+[Unreleased]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.4...HEAD
+[0.0.4]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.3...0.0.4
 [0.0.3]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.2...0.0.3
 [0.0.2]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.1...0.0.2
 [0.0.1]: https://github.com/cyberark/conjur-api-python3/tree/v0.0.1

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,6 +6,8 @@ RUN apk add --no-cache bash \
                        binutils \
                        build-base \
                        git \
+                       libffi-dev \
+                       openssl-dev \
                        python3 \
                        python3-dev
 

--- a/conjur/api.py
+++ b/conjur/api.py
@@ -70,7 +70,9 @@ class Api():
             logging.warning("'ssl_verify' is False - YOU ARE VULNERABLE TO MITM ATTACKS!")
             logging.warning("*" * 60)
 
+            #pylint: disable=import-outside-toplevel
             import urllib3
+
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         # WARNING: ONLY FOR DEBUGGING - DO NOT CHECK IN LINES BELOW UNCOMMENTED

--- a/conjur/client.py
+++ b/conjur/client.py
@@ -39,7 +39,7 @@ class Client():
     # what paramteres are allowed
     #pylint: disable=too-many-arguments,too-many-locals
     def __init__(self,
-                 account='default',
+                 account=None,
                  api_key=None,
                  ca_bundle=None,
                  debug=False,
@@ -61,7 +61,7 @@ class Client():
             'ca_bundle': ca_bundle,
         }
 
-        if not url or not account or not login_id or (not password and not api_key):
+        if not url or not login_id or (not password and not api_key):
             logging.info("Not all expected variables were provided. " \
                 "Using conjurrc as credential store...")
             try:
@@ -76,6 +76,11 @@ class Client():
 
             except Exception as exc:
                 raise ConfigException(exc)
+
+        # We only want to override missing account info with "default"
+        # if we can't find it anywhere else.
+        if config['account'] is None:
+            config['account'] = "default"
 
         if api_key:
             logging.info("Using API key from parameters...")

--- a/conjur/http.py
+++ b/conjur/http.py
@@ -81,8 +81,9 @@ def enable_http_logging(): #pragma: no cover
     raise RuntimeError("If this line gets checked in uncommented or"
                        "is removed, the PR should not be approved")
 
-    # pylint: disable=unreachable
+    # pylint: disable=unreachable,import-outside-toplevel
     import logging
+    #pylint: disable=import-outside-toplevel
     from http.client import HTTPConnection
     HTTPConnection.debuglevel = 1
 

--- a/conjur/version.py
+++ b/conjur/version.py
@@ -7,4 +7,4 @@ This module contains the version information about the project that
 is intended to be reused in multiple places.
 """
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -131,23 +131,20 @@ class ClientTest(unittest.TestCase):
             url='apiconfigurl',
         )
 
-    @patch('conjur.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.client.Api')
-    def test_client_passes_config_from_apiconfig_if_account_is_empty(self, mock_api_instance,
-            mock_api_config):
-        Client(url='http://foo', account=None, login_id='mylogin', password="mypass")
+    def test_client_does_not_pass_config_from_apiconfig_if_only_account_is_empty(
+            self, mock_api_instance):
+        Client(url='http://foo', login_id='mylogin', password="mypass")
 
         mock_api_instance.assert_called_with(
-            account='apiconfigaccount',
-            api_key='apiconfigapikey',
-            ca_bundle='apiconfigcabundle',
+            account='default',
+            ca_bundle=None,
             http_debug=False,
-            key1='value1',
-            key2='value2',
-            login_id='apiconfigloginid',
             ssl_verify=True,
             url='http://foo',
         )
+
+        mock_api_instance.return_value.login.assert_called_once_with('mylogin', 'mypass')
 
     @patch('conjur.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.client.Api')

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,4 +1,5 @@
 import os
+import re
 import unittest
 
 from conjur.config import Config
@@ -44,16 +45,17 @@ class ConfigTest(unittest.TestCase):
     def test_config_printed_shows_formatted_fields(self):
         test_data = str(Config(config_file=self.GOOD_CONJURRC, netrc_file=self.GOOD_NETRC))
 
-        self.assertEquals(test_data,
-            "config:\n" +
-            "    account: accountname\n" +
-            "    api_key: conjurapikey\n" +
-            "    ca_bundle: /cert/file/location\n" +
-            "    login_id: someadmin\n" +
-            "    plugins:\n" +
-            "    - foo\n" +
-            "    - bar\n" +
-            "    url: https://someurl/somepath\n")
+        self.assertRegex(test_data,
+            re.compile(
+                "^config:\n" +
+                "\s+account: accountname\n" +
+                "\s+api_key: conjurapikey\n" +
+                "\s+ca_bundle: /cert/file/location\n" +
+                "\s+login_id: someadmin\n" +
+                "\s+plugins:.*foo.*bar.*\n" +
+                "\s+url: https://someurl/somepath\n",
+                re.MULTILINE | re.DOTALL,
+            ))
 
     def test_config_with_no_conjurrc_raises_error(self):
         with self.assertRaises(FileNotFoundError):


### PR DESCRIPTION
Old code was effectively hardcoded to always use "default" as the
account name when an account name was not provided, including times
where this data was supposed to be pulled from .conjurrc. This change
ensures that we only default the account name iff it's the only filed
missing from a valid configuration.

Connected to #21 