### PR TITLE
Added policy deletion capabilities to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ Replaces a named policy with one from the provided file. This is
 usually a destructive invocation. Result is a dictionary object
 constructed from the returned JSON data.
 
+#### `delete_policy_file(policy_name, policy_file)`
+
+Modifies an existing Conjur policy. Data may be explicitly
+deleted using the !delete, !revoke, and !deny statements. Unlike
+"replace" mode, no data is ever implicitly deleted. Result is a
+dictionary object constructed from the returned JSON data.
+
 #### `list()`
 
 Returns a Python list of all the available resources for the current

--- a/conjur/api.py
+++ b/conjur/api.py
@@ -221,9 +221,10 @@ class Api():
                                value, api_token=self.api_token,
                                ssl_verify=self._ssl_verify).text
 
-    def apply_policy_file(self, policy_id, policy_file):
+
+    def _load_policy_file(self, policy_id, policy_file, http_verb):
         """
-        This method is used to load a file-based policy into the desired
+        This method is used to load, replace or delete a file-based policy into the desired
         name.
         """
 
@@ -236,12 +237,20 @@ class Api():
         with open(policy_file, 'r') as content_file:
             policy_data = content_file.read()
 
-        json_response = invoke_endpoint(HttpVerb.POST, ConjurEndpoint.POLICIES, params,
+        json_response = invoke_endpoint(http_verb, ConjurEndpoint.POLICIES, params,
                                         policy_data, api_token=self.api_token,
                                         ssl_verify=self._ssl_verify).text
 
         policy_changes = json.loads(json_response)
         return policy_changes
+
+    def apply_policy_file(self, policy_id, policy_file):
+        """
+        This method is used to load a file-based policy into the desired
+        name.
+        """
+
+        return self._load_policy_file(policy_id, policy_file, HttpVerb.POST)
 
     def replace_policy_file(self, policy_id, policy_file):
         """
@@ -249,18 +258,12 @@ class Api():
         policy ID.
         """
 
-        params = {
-            'identifier': policy_id,
-        }
-        params.update(self._default_params)
+        return self._load_policy_file(policy_id, policy_file, HttpVerb.PUT)
 
-        policy_data = None
-        with open(policy_file, 'r') as content_file:
-            policy_data = content_file.read()
+    def delete_policy_file(self, policy_id, policy_file):
+        """
+        This method is used to delete a file-based policy into the desired
+        policy ID.
+        """
 
-        json_response = invoke_endpoint(HttpVerb.PUT, ConjurEndpoint.POLICIES, params,
-                                        policy_data, api_token=self.api_token,
-                                        ssl_verify=self._ssl_verify).text
-
-        policy_changes = json.loads(json_response)
-        return policy_changes
+        return self._load_policy_file(policy_id, policy_file, HttpVerb.PATCH)

--- a/conjur/cli.py
+++ b/conjur/cli.py
@@ -71,6 +71,13 @@ class Cli():
         replace_policy_parser.add_argument('policy',
             help='File containing the YAML policy')
 
+        delete_policy_parser = policy_subparsers.add_parser('delete',
+            help='Delete a policy file')
+        delete_policy_parser.add_argument('name',
+            help='Name of the policy (usually "root")')
+        delete_policy_parser.add_argument('policy',
+            help='File containing the YAML policy')
+
 
         parser.add_argument('-v', '--version', action='version',
             version='%(prog)s v' + __version__)
@@ -149,6 +156,9 @@ class Cli():
         elif resource == 'policy':
             if args.action == 'replace':
                 resources = client.replace_policy_file(args.name, args.policy)
+                print(json.dumps(resources, indent=4))
+            elif args.action == 'delete':
+                resources = client.delete_policy_file(args.name, args.policy)
                 print(json.dumps(resources, indent=4))
             else:
                 resources = client.apply_policy_file(args.name, args.policy)

--- a/conjur/client.py
+++ b/conjur/client.py
@@ -147,3 +147,9 @@ class Client():
         Replaces a file-based policy defined in the Conjur instance
         """
         return self._api.replace_policy_file(policy_name, policy_file)
+
+    def delete_policy_file(self, policy_name, policy_file):
+        """
+        Replaces a file-based policy defined in the Conjur instance
+        """
+        return self._api.delete_policy_file(policy_name, policy_file)

--- a/conjur/http.py
+++ b/conjur/http.py
@@ -23,6 +23,7 @@ class HttpVerb(Enum):
     POST = auto()
     PUT = auto()
     DELETE = auto()
+    PATCH = auto()
 
 
 #pylint: disable=too-many-locals

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -381,6 +381,54 @@ class ApiTest(unittest.TestCase):
                               identifier='mypolicyname',
                               ssl_verify='ssl_verify')
 
+    # Policy delete
+
+    @patch('conjur.api.invoke_endpoint', return_value=MockClientResponse(text='{}'))
+    def test_delete_policy_invokes_http_client_correctly(self, mock_http_client):
+        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        def mock_auth():
+            return 'apitoken'
+        api.authenticate = mock_auth
+
+        api.delete_policy_file('mypolicyname', self.POLICY_FILE)
+
+        policy_data = None
+        with open(self.POLICY_FILE, 'r') as content_file:
+            policy_data = content_file.read()
+
+        self.verify_http_call(mock_http_client, HttpVerb.PATCH, ConjurEndpoint.POLICIES,
+                              policy_data,
+                              identifier='mypolicyname',
+                              ssl_verify=True)
+
+    @patch('conjur.api.invoke_endpoint', return_value=MockClientResponse(text=json.dumps(MOCK_POLICY_CHANGE_OBJECT)))
+    def test_delete_policy_converts_returned_data_to_expected_objects(self, mock_http_client):
+        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        def mock_auth():
+            return 'apitoken'
+        api.authenticate = mock_auth
+
+        output = api.delete_policy_file('mypolicyname', self.POLICY_FILE)
+        self.assertEqual(output, MOCK_POLICY_CHANGE_OBJECT)
+
+    @patch('conjur.api.invoke_endpoint', return_value=MockClientResponse(text='{}'))
+    def test_delete_policy_passes_down_ssl_verify_parameter(self, mock_http_client):
+        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey', ssl_verify='ssl_verify')
+        def mock_auth():
+            return 'apitoken'
+        api.authenticate = mock_auth
+
+        api.delete_policy_file('mypolicyname', self.POLICY_FILE)
+
+        policy_data = None
+        with open(self.POLICY_FILE, 'r') as content_file:
+            policy_data = content_file.read()
+
+        self.verify_http_call(mock_http_client, HttpVerb.PATCH, ConjurEndpoint.POLICIES,
+                              policy_data,
+                              identifier='mypolicyname',
+                              ssl_verify='ssl_verify')
+
     # Get variables
 
     @patch('conjur.api.invoke_endpoint', return_value=MockClientResponse(content='{"foo": "a", "bar": "b"}'))

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -152,6 +152,18 @@ class CliTest(unittest.TestCase):
     def test_cli_policy_replace_outputs_formatted_json(self, cli_invocation, output, client):
         self.assertEquals('{\n    "foo": "A",\n    "bar": "B"\n}\n', output)
 
+    @cli_test(["policy", "delete", "foo", "foopolicy"])
+    def test_cli_invokes_policy_delete_correctly(self, cli_invocation, output, client):
+        client.delete_policy_file.assert_called_once_with('foo', 'foopolicy')
+
+    @cli_test(["policy", "delete", "foo", "foopolicy"], policy_change_output={})
+    def test_cli_policy_delete_doesnt_break_on_empty_input(self, cli_invocation, output, client):
+        self.assertEquals('{}\n', output)
+
+    @cli_test(["policy", "delete", "foo", "foopolicy"], policy_change_output={"foo": "A", "bar": "B"})
+    def test_cli_policy_delete_outputs_formatted_json(self, cli_invocation, output, client):
+        self.assertEquals('{\n    "foo": "A",\n    "bar": "B"\n}\n', output)
+
     @cli_test(["list"], list_output=RESOURCE_LIST)
     def test_cli_invokes_resource_listing_correctly(self, cli_invocation, output, client):
         client.list.assert_called_once_with()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -313,6 +313,28 @@ class ClientTest(unittest.TestCase):
         return_value = Client().replace_policy_file('name', 'policy')
         self.assertEquals(return_value, replace_policy_result)
 
+
+    @patch('conjur.client.ApiConfig', return_value=MockApiConfig())
+    @patch('conjur.client.Api')
+    def test_client_passes_through_api_delete_policy_params(self, mock_api_instance,
+            mock_api_config):
+        Client().delete_policy_file('name', 'policy')
+
+        mock_api_instance.return_value.delete_policy_file.assert_called_once_with(
+            'name',
+            'policy'
+        )
+
+    @patch('conjur.client.ApiConfig', return_value=MockApiConfig())
+    @patch('conjur.client.Api')
+    def test_client_returns_delete_policy_result(self, mock_api_instance,
+            mock_api_config):
+        delete_policy_result = uuid.uuid4().hex
+        mock_api_instance.return_value.delete_policy_file.return_value = delete_policy_result
+
+        return_value = Client().delete_policy_file('name', 'policy')
+        self.assertEquals(return_value, delete_policy_result)
+
     @patch('conjur.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.client.Api')
     def test_client_passes_through_resource_list_method(self, mock_api_instance,

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -15,6 +15,7 @@ class HttpVerbTest(unittest.TestCase):
         self.assertTrue(HttpVerb.PUT)
         self.assertTrue(HttpVerb.POST)
         self.assertTrue(HttpVerb.DELETE)
+        self.assertTrue(HttpVerb.PATCH)
 
 
 class HttpInvokeEndpointTest(unittest.TestCase):

--- a/test/util/cli_helpers.py
+++ b/test/util/cli_helpers.py
@@ -43,6 +43,7 @@ def cli_test(cli_args=[], integration=False, get_many_output=None, list_output=N
             client_instance_mock.list.return_value = list_output
             client_instance_mock.apply_policy_file.return_value = policy_change_output
             client_instance_mock.replace_policy_file.return_value = policy_change_output
+            client_instance_mock.delete_policy_file.return_value = policy_change_output
 
             with self.assertRaises(SystemExit) as sys_exit:
                 with redirect_stdout(capture_stream):


### PR DESCRIPTION
Now we will be able to perform the PATCH method when
loading in policy which allows the ability to explicitly
delete specific resources.

Resolves #23 