### PR TITLE
Fixed issues related to conversion of test container to Ubuntu

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,7 +6,9 @@ RUN apt-get update && \
     apt-get install -y bash \
                        binutils \
                        build-essential \
+                       curl \
                        git \
+                       jq \
                        libffi-dev \
                        libssl-dev \
                        python3 \

--- a/bin/needs_publishing
+++ b/bin/needs_publishing
@@ -22,11 +22,18 @@ fi
 echo "Published version ($published_version) does not match local version ($local_version)!"
 echo "Checking current git tag to see if it matches this commit..."
 
+# Git fetch will fail if we don't have the host added in our known_hosts
+# which will happen in a clean container
+echo "Adding ssh key of GitHub to known_hosts..."
+mkdir -p ~/.ssh
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+
 # Jenkins git plugin is broken and always fetches with `--no-tags`
 # (or `--tags`, neither of which is what you want), so tags end up
 # not being fetched. Try to fix that.
 # (Unfortunately this fetches all remote heads, so we may have to find
 # another solution for bigger repos.)
+echo "Fetching known tags..."
 git fetch -q
 
 tag_commit=$(git rev-list -n 1 "v$local_version" 2>/dev/null || true)

--- a/bin/publish_package
+++ b/bin/publish_package
@@ -26,7 +26,7 @@ docker run --rm \
            -v "$(pwd):/opt/conjur-api-python3" \
            conjur-api-python3-test bash -exc "
                echo 'Installing new versions of pip and wheel...'
-               /usr/bin/env pip3 install --progress-bar off --upgrade pip wheel
+               /usr/bin/env pip3 install --upgrade pip wheel
 
                if ! ./bin/needs_publishing \$TWINE_REPOSITORY_URL; then
                  echo 'WARN: Publishing skipped!'


### PR DESCRIPTION
There were additional missing things changed:
- `jq` and `curl` were installed
- `pip3` invocation removed a flag that wasn't available on Ubuntu
- ssh key of github is added to known_hosts since it won't be
  present in the Ubuntu container and it blocks tag fetching