### PR TITLE
Tag the CLI image during builds with addition full-version tag

### DIFF
--- a/bin/build_cli_container
+++ b/bin/build_cli_container
@@ -2,6 +2,10 @@
 
 echo "Building CLI container..."
 
+VERSION=$(cat conjur/version.py | grep '__version__' | sed -e "s/.*'\(.*\)'.*/\\1/")
+FULL_VERSION_TAG="$VERSION-$(git rev-parse --short HEAD)"
+
 docker build -f Dockerfile \
              -t conjur-python-cli \
+             -t "conjur-python-cli:${FULL_VERSION_TAG}" \
              .


### PR DESCRIPTION
This should allow other scripts (like publishing) to anticipate what
image to use. We can't use just `latest` as this will make the runs have
a race condition on builds colocated on the same builder.