### PR TITLE
Make publishing stages run in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,25 +41,28 @@ pipeline {
       }
     }
 
-    // Only publish to PyPI if the HEAD is
-    // tagged with the same version as in __version__.py
-    stage('Publish to PyPI') {
-      steps {
-        sh 'summon -e production ./bin/publish_package'
-      }
+    // Only publish if the HEAD is tagged with the same version as in __version__.py
+    stage('Publish') {
+      parallel {
+        stage('Publish to PyPI') {
+          steps {
+            sh 'summon -e production ./bin/publish_package'
+          }
 
-      when {
-        branch "master"
-      }
-    }
+          when {
+            branch "master"
+          }
+        }
 
-    stage('Publish containers') {
-      steps {
-        sh './bin/publish_container'
-      }
+        stage('Publish containers') {
+          steps {
+            sh './bin/publish_container'
+          }
 
-      when {
-        branch "master"
+          when {
+            branch "master"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This will allow them to run faster and to not block each other on
problems.