### PR TITLE
Removed out references to `enum.auto` to support Python 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Removed references to `enum.auto` to support Python3.5 [#43](https://github.com/cyberark/conjur-api-python3/issues/43).
+
 ## [0.1.0] - 2020-01-03
 ### Added
 - Added ability to publish the container to DockerHub [#28](https://github.com/cyberark/conjur-api-python3/issues/28)

--- a/conjur/http.py
+++ b/conjur/http.py
@@ -8,7 +8,7 @@ HTTP-based endpoints in a generic way
 """
 
 import base64
-from enum import auto, Enum
+from enum import Enum
 from urllib.parse import quote
 
 import requests
@@ -19,11 +19,11 @@ class HttpVerb(Enum):
     Enumeration of all possible HTTP methods that we may use against
     the HTTP API endpoint
     """
-    GET = auto()
-    POST = auto()
-    PUT = auto()
-    DELETE = auto()
-    PATCH = auto()
+    GET = 1
+    POST = 2
+    PUT = 3
+    DELETE = 4
+    PATCH = 5
 
 
 #pylint: disable=too-many-locals

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -1,6 +1,6 @@
 import unittest
 
-from enum import auto, Enum
+from enum import Enum
 from unittest.mock import patch
 
 import requests


### PR DESCRIPTION
This early Python3 version might be used in some setups so we removed
out the auto command that didn't add too much in functionality.

Connected to #43 