### PR TITLE
Adding trivy scanning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,6 +71,16 @@ pipeline {
         }
       }
     }
+
+    stage('Scan Docker image') {
+      steps{
+        scanAndReport("conjur-python-cli:latest", "NONE")
+      }
+
+      when {
+        branch "master"
+      }
+    }
   }
 
   post {


### PR DESCRIPTION
Adds trivy scanning to Jenkins pipeline (will only run in master due to how image is built and published in one stage).
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>