### PR TITLE
Builds fail only on fixable HIGH or CRITICAL vulns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,8 +73,18 @@ pipeline {
     }
 
     stage('Scan Docker image') {
-      steps{
-        scanAndReport("conjur-python-cli:latest", "CRITICAL")
+      parallel {
+        stage('Scan Docker image for fixable vulns') {
+          steps {
+            scanAndReport("conjur-python-cli:latest", "HIGH", false)
+          }
+        }
+
+        stage('Scan Docker image for total vulns') {
+          steps {
+            scanAndReport("conjur-python-cli:latest", "NONE", true)
+          }
+        }
       }
 
       when {


### PR DESCRIPTION
Changes the trivy scan to do 2 reports - one of just fixable potential vulnerabilites and one with all detected potential vulnerabilities (whether a fix is available or not). Builds will only fail when there is a fix available. I also bumped the build failure threshold so builds will fail on fixable HIGH or CRITICAL vulnerabilities instead of just CRITICAL, as there should be no fixable HIGHs currently. 
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>