### PR TITLE
Add nightly build trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,10 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
 
+  triggers {
+    cron(getDailyCronString())
+  }
+
   stages {
     stage('Linting') {
       parallel {


### PR DESCRIPTION
This will prevent us from hitting issues with the code much earlier
rather than having someone proactively find them.