### PR TITLE
Upgrade urllib to 1.25.9+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ PyYAML>=3.13
 requests>=2.21.0
 twine>=1.13.0
 
-# https://github.com/kennethreitz/requests/issues/5065
-urllib3>=1.24.2,<1.25
+# https://nvd.nist.gov/vuln/detail/CVE-2020-26137
+urllib3>=1.25.9

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,13 @@ setup(
     # Keep this in sync with requirements.txt
     install_requires=[
         "nose2>=0.8.0",
-        "requests>=2.21.0",
+        "nose2[coverage_plugin]>=0.6.5",
+        "pylint>=2.3.1",
+        "PyInstaller>=3.4",
         "PyYAML>=3.13",
+        "requests>=2.21.0",
+        "twine>=1.13.0",
+        "urllib3>=1.25.9"
     ],
 
     package_data={


### PR DESCRIPTION
urllib3 before 1.25.9 allows CRLF injection if the attacker controls the HTTP request method,
as demonstrated by inserting CR and LF control characters in the first argument of putrequest().
NOTE: this is similar to CVE-2020-26116.