### PR TITLE
Bump version to v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [0.1.1] - 2020-11-05
+
+### Added
+- Method `whoami`is now availabe in both CLI and API (requires Conjur v1.9+).
+  [cyberark/conjur-api-python3#68](https://github.com/cyberark/conjur-api-python3/pull/68)
+
 ### Changed
 - Removed references to `enum.auto` to support Python3.5 [#43](https://github.com/cyberark/conjur-api-python3/issues/43).
 
@@ -47,7 +53,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The first tagged version.
 
-[Unreleased]: https://github.com/conjurinc/conjur-api-python3/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/conjurinc/conjur-api-python3/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/conjurinc/conjur-api-python3/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.5...v0.1.0
 [0.0.5]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/conjurinc/conjur-api-python3/compare/v0.0.3...v0.0.4

--- a/conjur/version.py
+++ b/conjur/version.py
@@ -7,4 +7,4 @@ This module contains the version information about the project that
 is intended to be reused in multiple places.
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'


### PR DESCRIPTION
A release is needed with the latest updates so this change increases the
version to v0.1.1

### What ticket does this PR close?
Connected to: #54

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation