### PR TITLE
Fixed typo in PyYAML dependency version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "nose2[coverage_plugin]>=0.6.5",
         "pylint>=2.6.0",
         "PyInstaller>=4.0",
-        "PyYAML>=5.31",
+        "PyYAML>=5.3.1",
         "requests>=2.24.0",
         "twine>=3.2.0",
         "urllib3>=1.25.9"


### PR DESCRIPTION
`setup.py` had a wrong dependency version entered for PyYAML during
version upgrade which this commit fixes.

### What ticket does this PR close?
Resolves #75 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation