### PR TITLE
Add CLI installation script for macOS

### DIFF
--- a/release/assets/macos_cli_setup.sh
+++ b/release/assets/macos_cli_setup.sh
@@ -1,5 +1,3 @@
-#!/bin/bash -e
-
 USER_PROVIDED_PATH=$1
 
 print_help() {
@@ -10,15 +8,25 @@ Conjur CLI setup script
 Installs and configures the Conjur CLI on macOS environments.
 Upon completion of this setup script, you will be able to access the Conjur CLI from anywhere on your machine.
 The installation creates a symbolic link between the CLI executable and directory path. By default, this path is '/usr/local/bin'.
-To overwrite this path, configure the directory path parameter.
+To overwrite this path, configure the directory path parameter. For example '$0 /usr/bin'
 
-For example ./macos_cli_installation.sh /usr/bin
-
-Usage: ./macos_cli_setup.sh [options]
+Usage: $0 [options]
     -h, --help    Shows this help message
 
 EOF
   exit
+}
+
+# Creates symbolic link to the path of the user's choice. Default location: '/usr/local/bin'
+create_symbolic_link() {
+  local executable_path=$1
+  # Get relative from where the script is being run
+  relative_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+  ln -s -f /$relative_path/conjur $executable_path
+  if [ $? -ne 0 ]; then
+    echo "Error: Unable to create symbolic link between the provided path and the Conjur executable. Ensure that the provided paths exist."
+    exit 1
+  fi
 }
 
 main() {
@@ -30,25 +38,28 @@ main() {
 \____/\____/_/ /_/_/ /\____//_/
                 /___/
 EOF
-
-  if [[ $USER_PROVIDED_PATH = "--help" ]]; then
+  if [[ $USER_PROVIDED_PATH = "--help" || $USER_PROVIDED_PATH = "-h" ]]; then
     print_help
   fi
   executable_path=${USER_PROVIDED_PATH:-'/usr/local/bin'}
 
+  if [[ ! -d "/usr/local/bin" ]]; then
+    echo "The default directory '/usr/local/bin' does not exist or you do not have permissions to access it." \
+    "Provide the path to the user directory to create the symbolic link. For example: '$0 /usr/bin'."
+    exit 1
+  fi
+
   echo "Setting up the Conjur CLI. This will take a few moments...."
   create_symbolic_link $executable_path
 
-  # the first run of the CLI is always the longest. Here we are running the
+  # The first run of the CLI is always the longest. Here we are running the
   # first run of the CLI for the user to hideaway this lag
   conjur --help > /dev/null
+  if [ $? -ne 0 ]; then
+    echo "Error: The Conjur CLI executable was not found in the current directory."
+    exit 1
+  fi
   echo "Successfully setup the Conjur CLI. To get started, run 'conjur --help'"
-}
-
-# Creates symbolic link to the path of the user's choice. Default location: '/usr/local/bin'
-create_symbolic_link() {
-  local executable_path=$1
-  ln -s -f /$PWD/conjur $executable_path
 }
 
 main

--- a/release/assets/macos_cli_setup.sh
+++ b/release/assets/macos_cli_setup.sh
@@ -59,7 +59,7 @@ EOF
     echo "Error: The Conjur CLI executable was not found in the current directory."
     exit 1
   fi
-  echo "Successfully setup the Conjur CLI. To get started, run 'conjur --help'"
+  echo "Successfully set up the Conjur CLI. To get started, run 'conjur --help'"
 }
 
 main

--- a/release/assets/macos_cli_setup.sh
+++ b/release/assets/macos_cli_setup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -e
+
+USER_PROVIDED_PATH=$1
+
+print_help() {
+  cat << EOF
+
+Conjur CLI setup script
+
+Installs and configures the Conjur CLI on macOS environments.
+Upon completion of this setup script, you will be able to access the Conjur CLI from anywhere on your machine.
+The installation creates a symbolic link between the CLI executable and directory path. By default, this path is '/usr/local/bin'.
+To overwrite this path, configure the directory path parameter.
+
+For example ./macos_cli_installation.sh /usr/bin
+
+Usage: ./macos_cli_setup.sh [options]
+    -h, --help    Shows this help message
+
+EOF
+  exit
+}
+
+main() {
+  cat << EOF
+   ______
+  / ____/___  ____    ( )_  ________
+ / /   / __ \/ __ \  / / / / // ___/
+/ /___/ /_/ / / / / / / /_/ // /
+\____/\____/_/ /_/_/ /\____//_/
+                /___/
+EOF
+
+  if [[ $USER_PROVIDED_PATH = "--help" ]]; then
+    print_help
+  fi
+  executable_path=${USER_PROVIDED_PATH:-'/usr/local/bin'}
+
+  echo "Setting up the Conjur CLI. This will take a few moments...."
+  create_symbolic_link $executable_path
+
+  # the first run of the CLI is always the longest. Here we are running the
+  # first run of the CLI for the user to hideaway this lag
+  conjur --help > /dev/null
+  echo "Successfully setup the Conjur CLI. To get started, run 'conjur --help'"
+}
+
+# Creates symbolic link to the path of the user's choice. Default location: '/usr/local/bin'
+create_symbolic_link() {
+  local executable_path=$1
+  ln -s -f /$PWD/conjur $executable_path
+}
+
+main


### PR DESCRIPTION
### What does this PR do?
This PR adds the CLI installation script for macOS environments to the repo. This script will be compressed together with the CLI binaries and delivered to customers in our release page.

Previously the CLI on macOS environments was taking upwards of 15+ seconds on each run. This is because of a security policy on macOS machines that extracts executables and scans them. To account for this, we will pack the CLI as a directory instead of a single executable file and create a symbolic link between the directory and /usr/local/bin. This script hides away these details for the user 

### What ticket does this PR close?
Resolves #126 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
Separate issue