### PR TITLE
Expand TLS version communication to 1.2 and 1.3

### DIFF
--- a/conjur/ssl_service.py
+++ b/conjur/ssl_service.py
@@ -12,10 +12,11 @@ import socket
 from OpenSSL import SSL
 from OpenSSL.crypto import FILETYPE_PEM, dump_certificate
 
-_tls_methods = {
+_conjur_tls_methods = {
     "1.0": SSL.TLSv1_METHOD,
     "1.1": SSL.TLSv1_1_METHOD,
-    "1.2": SSL.TLSv1_2_METHOD
+    "1.2": SSL.TLSv1_2_METHOD,
+    "1.3": SSL.SSLv23_METHOD
 }
 
 # pylint: disable=too-few-public-methods
@@ -44,10 +45,20 @@ class SSLService:
         """
         Method for opening a socket to the Conjur server
         """
+        tls_version=os.getenv('CONJUR_TLS_VERSION')
         # Makes the TLS version configurable through an ENV variable
-        if os.getenv('TLS_VERSION') in _tls_methods:
-            ctx = SSL.Context(method=_tls_methods[os.getenv('TLS_VERSION')])
+        if tls_version in _conjur_tls_methods:
+            # pylint: disable=logging-fstring-interpolation
+            logging.debug("'CONJUR_TLS_VERSION' environment variable supplied. Establishing TLS "
+                          f"v{tls_version} connection...")
+            ctx = SSL.Context(method=_conjur_tls_methods[tls_version])
+            if tls_version == '1.3':
+                # disables all TLS versions expect for 1.3
+                cls.disable_tls_versions(ctx, support_1_3=True)
         else:
+            if tls_version:
+                logging.debug("Warning: 'CONJUR_TLS_VERSION' environment variable supplied but "
+                              "not in correct format (Example: CONJUR_TLS_VERSION=1.2)")
             # Despite its name, SSLv23_METHOD is the alias for PROTOCOL_TLS which allows for
             # negotiation between different TLS versions and chooses the highest supported server
             # protocol. See https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_SSLv23
@@ -55,15 +66,8 @@ class SSLService:
             ctx = SSL.Context(method=SSL.SSLv23_METHOD)
             # Using SSLv23 by default enables all types of negotiation and we want to limit
             # negotiation to only 1.2 and 1.3 versions
-            ctx.set_options(SSL.OP_NO_SSLv2)
-            ctx.set_options(SSL.OP_NO_SSLv3)
-            ctx.set_options(SSL.OP_NO_TLSv1)
-            ctx.set_options(SSL.OP_NO_TLSv1_1)
+            cls.disable_tls_versions(ctx)
 
-        # We set the following to false because we want to fetch the
-        # certificates and not use them to validate yet
-        ctx.check_hostname = False
-        ctx.verify_mode = False
         # pylint: disable = line-too-long
         # Taken from https://gist.github.com/brandond/f3d28734a40c49833176207b17a44786#file-sslscan-py-L17
         conjur_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -75,3 +79,17 @@ class SSLService:
                       "Fetching certificate from Conjur server")
 
         return conjur_sock
+
+    @classmethod
+    def disable_tls_versions(cls, ctx, support_1_3=False):
+        """
+        Method for disabling TLS/SSL versions
+        """
+        if support_1_3:
+            # disable TLS 1.2 when user requires only 1.3
+            ctx.set_options(SSL.OP_NO_TLSv1_2)
+
+        ctx.set_options(SSL.OP_NO_SSLv2)
+        ctx.set_options(SSL.OP_NO_SSLv3)
+        ctx.set_options(SSL.OP_NO_TLSv1)
+        ctx.set_options(SSL.OP_NO_TLSv1_1)

--- a/conjur/ssl_service.py
+++ b/conjur/ssl_service.py
@@ -7,9 +7,16 @@ This module is for all SSL operations
 """
 # Third party
 import logging
+import os
 import socket
 from OpenSSL import SSL
 from OpenSSL.crypto import FILETYPE_PEM, dump_certificate
+
+_tls_methods = {
+    "1.0": SSL.TLSv1_METHOD,
+    "1.1": SSL.TLSv1_1_METHOD,
+    "1.2": SSL.TLSv1_2_METHOD
+}
 
 # pylint: disable=too-few-public-methods
 class SSLService:
@@ -37,7 +44,22 @@ class SSLService:
         """
         Method for opening a socket to the Conjur server
         """
-        ctx = SSL.Context(method=SSL.TLSv1_2_METHOD)
+        # Makes the TLS version configurable through an ENV variable
+        if os.getenv('TLS_VERSION') in _tls_methods:
+            ctx = SSL.Context(method=_tls_methods[os.getenv('TLS_VERSION')])
+        else:
+            # Despite its name, SSLv23_METHOD is the alias for PROTOCOL_TLS which allows for
+            # negotiation between different TLS versions and chooses the highest supported server
+            # protocol. See https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_SSLv23
+            # specifically PROTOCOL_SSLv23 and PROTOCOL_TLS
+            ctx = SSL.Context(method=SSL.SSLv23_METHOD)
+            # Using SSLv23 by default enables all types of negotiation and we want to limit
+            # negotiation to only 1.2 and 1.3 versions
+            ctx.set_options(SSL.OP_NO_SSLv2)
+            ctx.set_options(SSL.OP_NO_SSLv3)
+            ctx.set_options(SSL.OP_NO_TLSv1)
+            ctx.set_options(SSL.OP_NO_TLSv1_1)
+
         # We set the following to false because we want to fetch the
         # certificates and not use them to validate yet
         ctx.check_hostname = False


### PR DESCRIPTION
When a user runs 'init' command, we open a socket with Conjur, fetch the certificate for them from the Conjur server and save it on their local machine.

We were previously limiting the context to to communicate over TLS 1.2 to fetch the certificate from the Conjur server. This change expands this to also support 1.3 and block anything less than 1.2. This option can now be configured via an environment variable.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation