### PR TITLE
Update CODEOWNERS to Palmtree from Community and Integrations team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @cyberark/community-and-integrations-team @conjurinc/community-and-integrations-team @conjurdemos/community-and-integrations-team
+* @cyberark/palmtree @conjurinc/palmtree @conjurdemos/palmtree
 
 # Changes to .trivyignore require Security Architect approval
 .trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects


### PR DESCRIPTION
### What does this PR do?
Updates codeowners in the repo to be Palmtree by default