### PR TITLE
Remove readline import

### DIFF
--- a/conjur/host/host_controller.py
+++ b/conjur/host/host_controller.py
@@ -8,10 +8,6 @@ This module is the controller that facilitates all host actions
 
 # Builtins
 import sys
-# Allows users to move left and right when inputting input instead of printing escape characters
-# https://stackoverflow.com/questions/58591423/python-prints-escape-keys-while-entering-input-when-pressing-the-arrow-keys-on-t
-# pylint: disable=unused-import
-import readline
 
 # Internals
 from conjur.errors import MissingRequiredParameterException

--- a/conjur/init/init_controller.py
+++ b/conjur/init/init_controller.py
@@ -10,10 +10,6 @@ required to successfully configure the conjurrc
 # Builtins
 import logging
 import sys
-# Allows users to move left and right when inputting input instead of printing escape characters
-# https://stackoverflow.com/questions/58591423/python-prints-escape-keys-while-entering-input-when-pressing-the-arrow-keys-on-t
-# pylint: disable=unused-import
-import readline
 
 # Third party
 from urllib.parse import urlparse
@@ -57,7 +53,7 @@ class InitController:
         """
         # pylint: disable=line-too-long
         if self.conjurrc_data.appliance_url is None:
-            self.conjurrc_data.appliance_url = input("Enter the URL of your Conjur server (using https://): ").strip()
+            self.conjurrc_data.appliance_url = input("Enter the URL of your Conjur server (use HTTPS prefix): ").strip()
             if self.conjurrc_data.appliance_url == '':
                 # pylint: disable=raise-missing-from
                 raise RuntimeError("Error: URL is required")

--- a/conjur/login/login_controller.py
+++ b/conjur/login/login_controller.py
@@ -11,10 +11,6 @@ required to successfully configure the Credentials
 import getpass
 import logging
 import sys
-# pylint: disable=unused-import
-# Allows users to move left and right when inputting input instead of printing escape characters
-# https://stackoverflow.com/questions/58591423/python-prints-escape-keys-while-entering-input-when-pressing-the-arrow-keys-on-t
-import readline
 
 from Utils.utils import Utils
 from conjur.constants import CREDENTIAL_HOST_PATH, DEFAULT_NETRC_FILE


### PR DESCRIPTION
### What does this PR do?
The readline import was an import added to avoid replacing the line when running CTLR+C to stop a process. This lead to the Windows executable not working on deployment. This PR removes readline traces in the codebase