### PR TITLE
Fix broken pipeline on cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 nose2>=0.9.2
 nose2[coverage_plugin]>=0.6.5
 pylint>=2.6.0
+cryptography~=3.3.1
 pyopenssl>=20.0.0
 PyInstaller>=4.0
 PyYAML>=5.3.1


### PR DESCRIPTION
### What does this PR do?
A bump in the cryptography indirect dependency lead to cascading breaking changes in our direct dependency pyopenssl. This PR fixes this by directing adding cryptography to our requirements.txt and reverting to a previous cryptography version.


![image](https://user-images.githubusercontent.com/73157235/107208735-aa0b0c00-6a0a-11eb-8b00-02e5f77b116c.png)

New Release of cryptography version 3.4.1 broke our pipeline. Currently We will use the previous version 3.3.1 and and issue will open to investigate it future https://github.com/cyberark/conjur-api-python3/issues/184

For more reading about the rust problem in new cryptography version you can read in their github page : https://github.com/pyca/cryptography/issues/5771



### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or. 
- [ ] This PR does not require updating any documentation