### PR TITLE
Add ability to run init in insecure mode

### DIFF
--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -149,7 +149,7 @@ class Client():
     # Technical debt: refactor when time permits because this function
     # doesn't belong here
     @staticmethod
-    def initialize(url, account, cert, force):
+    def initialize(url, account, cert, force, ssl_verify):
         """
         Initializes the client, creating the .conjurrc file
         """
@@ -163,7 +163,8 @@ class Client():
 
         input_controller = InitController(conjurrc_data,
                                           init_logic,
-                                          force)
+                                          force,
+                                          ssl_verify)
         input_controller.load()
 
     ### API passthrough

--- a/conjur/cli.py
+++ b/conjur/cli.py
@@ -564,11 +564,12 @@ Copyright (c) 2021 CyberArk Software Ltd. All rights reserved.
             sys.exit(0)
 
     @classmethod
-    def handle_init_logic(cls, url=None, name=None, certificate=None, force=None):
+    # pylint: disable=too-many-arguments
+    def handle_init_logic(cls, url=None, name=None, certificate='', force=None, ssl_verify=True):
         """
         Method that wraps the init call logic
         """
-        Client.initialize(url, name, certificate, force)
+        Client.initialize(url, name, certificate, force, ssl_verify=ssl_verify)
 
     @classmethod
     def handle_login_logic(cls, identifier=None, password=None, ssl_verify=True):
@@ -674,9 +675,9 @@ Copyright (c) 2021 CyberArk Software Ltd. All rights reserved.
         api class method with the specified parameters.
         """
         Client.setup_logging(Client, args.debug)
-        # pylint: disable=no-else-return
+        # pylint: disable=no-else-return,line-too-long
         if resource == 'init':
-            Cli.handle_init_logic(args.url, args.name, args.certificate, args.force)
+            Cli.handle_init_logic(args.url, args.name, args.certificate, args.force, args.ssl_verify)
             # A successful exit is required to prevent the initialization of
             # the Client because the init command does not require the Client
             return

--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 # Internals
 from conjur.constants import DEFAULT_CERTIFICATE_FILE, DEFAULT_CONFIG_FILE
+from conjur.util import util_functions
 
 class InitController:
     """
@@ -27,7 +28,11 @@ class InitController:
     conjurrc_data = None
     init_logic = None
 
-    def __init__(self, conjurrc_data, init_logic, force):
+    def __init__(self, conjurrc_data, init_logic, force, ssl_verify):
+        self.ssl_verify = ssl_verify
+        if self.ssl_verify is False:
+            util_functions.get_insecure_warning()
+
         self.conjurrc_data = conjurrc_data
         self.init_logic = init_logic
         self.force_overwrite = force
@@ -36,11 +41,13 @@ class InitController:
         """
         Method that facilitates all method calls in this class
         """
-        fetched_certificate = self.get_server_certificate()
-        self.write_certificate(fetched_certificate)
+        if self.ssl_verify is True:
+            fetched_certificate = self.get_server_certificate()
+            self.write_certificate(fetched_certificate)
+        else:
+            self.conjurrc_data.cert_file=""
 
         self.get_account_info(self.conjurrc_data)
-
         self.write_conjurrc()
 
         sys.stdout.write("Configuration was initialized successfully.\n")

--- a/conjur/logic/init_logic.py
+++ b/conjur/logic/init_logic.py
@@ -104,8 +104,7 @@ class InitLogic:
 
             # Ensures that there are no None fields written to conjurrc
             for attr,value in conjurrc_data.__dict__.items():
-                if value is not None:
-                    _pretty_print_object[str(attr)]=value
+                _pretty_print_object[str(attr)]=value
 
             config_fp.write("---\n")
             yaml.dump(_pretty_print_object, config_fp)

--- a/test/test_integration_configurations.py
+++ b/test/test_integration_configurations.py
@@ -45,12 +45,36 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
         return self.invoke_cli(self.cli_auth_params,
                                ['list'], exit_code=exit_code)
 
-    # *************** INITIAL INIT CONFIGURATION TESTS ***************
+    # *************** INIT CONFIGURATION TESTS ***************
+
+    '''
+    Validates that the conjurrc cert_file entry is blank when run in --insecure mode
+    '''
+    @integration_test(True)
+    @patch('builtins.input', return_value='yes')
+    def test_https_conjurrc_in_insecure_mode_leaves_cert_file_empty(self, mock_input):
+        self.setup_cli_params({})
+        self.invoke_cli(self.cli_auth_params,
+                        ['--insecure', 'init', '--url', self.client_params.hostname, '--account', 'someaccount'])
+
+        utils.verify_conjurrc_contents('someaccount', self.client_params.hostname, '')
+
+    '''
+    Validates that certificate flag is overwritten when running in --insecure mode
+    '''
+    @integration_test(True)
+    @patch('builtins.input', return_value='yes')
+    def test_https_conjurrc_provided_cert_file_path_is_overwritten_in_insecure_mode(self, mock_input):
+        self.setup_cli_params({})
+        self.invoke_cli(self.cli_auth_params,
+                        ['--insecure', 'init', '--url', self.client_params.hostname, '--account', 'someaccount',
+                         '--certificate', self.environment.path_provider.certificate_path])
+
+        utils.verify_conjurrc_contents('someaccount', self.client_params.hostname, '')
 
     '''
     Validates that the conjurrc was created on the machine
     '''
-
     @integration_test(True)
     @patch('builtins.input', return_value='yes')
     def test_https_conjurrc_is_created_with_all_parameters_given(self, mock_input):
@@ -58,6 +82,7 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
         self.invoke_cli(self.cli_auth_params,
                         ['init', '--url', self.client_params.hostname, '--account', 'someaccount'])
 
+        utils.verify_conjurrc_contents('someaccount', self.client_params.hostname, self.environment.path_provider.certificate_path)
         assert os.path.isfile(DEFAULT_CERTIFICATE_FILE)
 
     '''
@@ -65,11 +90,12 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
     '''
     @integration_test()
     @patch('builtins.input', return_value='yes')
-    def test_https_conjurrc_is_created_with_all_parameters_given(self, mock_input):
+    def test_https_conjurrc_is_created_successfully_with_extra_slash_in_url(self, mock_input):
         self.setup_cli_params({})
         self.invoke_cli(self.cli_auth_params,
                         ['init', '--url', self.client_params.hostname+"/", '--account', 'someaccount'])
 
+        utils.verify_conjurrc_contents('someaccount', self.client_params.hostname, self.environment.path_provider.certificate_path)
         assert os.path.isfile(DEFAULT_CERTIFICATE_FILE)
 
     '''

--- a/test/test_integration_policy.py
+++ b/test/test_integration_policy.py
@@ -106,7 +106,7 @@ class CliIntegrationPolicy(IntegrationTestCaseBase):  # pragma: no cover
     @integration_test(True)
     def test_policy_load_raises_file_not_exists_error(self):
         output = self.invoke_cli(self.cli_auth_params,
-                                 ['policy', 'load', '-b', 'root', '-f', 'somepolicy.yml'], exit_code=1)
+                                 ['policy', 'load', '-b', 'root', '-f', 'somenonexistantpolicy.yml'], exit_code=1)
         self.assertRegex(output, "Error: No such file or directory:")
 
     '''

--- a/test/test_unit_cli.py
+++ b/test/test_unit_cli.py
@@ -264,13 +264,14 @@ Copyright (c) 2021 CyberArk Software Ltd. All rights reserved.
     def test_run_action_runs_init_logic(self, mock_setup_logging, mock_handle_init):
         mock_obj = MockArgs()
         mock_obj.url = 'https://someurl'
+        mock_obj.ssl_verify = True
         mock_obj.name = 'somename'
         mock_obj.certificate = 'somecert'
         mock_obj.force = 'force'
         mock_obj.debug = 'somedebug'
 
         Cli().run_action('init', mock_obj)
-        mock_handle_init.assert_called_once_with('https://someurl', 'somename', 'somecert', 'force')
+        mock_handle_init.assert_called_once_with('https://someurl', 'somename', 'somecert', 'force', True)
 
     @patch.object(Cli, 'handle_login_logic')
     @patch.object(Client, 'setup_logging')

--- a/test/test_unit_client.py
+++ b/test/test_unit_client.py
@@ -86,7 +86,7 @@ class ClientTest(unittest.TestCase):
         client = Client
         mock_init_controller = InitController
         mock_init_controller.load = MagicMock()
-        Client.initialize('someurl', 'someaccount', '/some/path/to/pem', False)
+        Client.initialize('someurl', 'someaccount', '/some/path/to/pem', False, True)
         mock_init_controller.load.assert_called_once()
 
     @patch('conjur.api.client.ApiConfig', new=MissingMockApiConfig)

--- a/test/util/test_helpers.py
+++ b/test/util/test_helpers.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 # *************************************************
 # *********** INTEGRATION TESTS HELPERS ***********
 # *************************************************
+from conjur.constants import DEFAULT_CONFIG_FILE
+
 
 def remove_file(file_path):
     if os.path.isfile(file_path):
@@ -36,6 +38,17 @@ def login_to_cli(self):
 def setup_cli(self):
     init_to_cli(self)
     login_to_cli(self)
+
+ # *************** INIT ***************
+
+def verify_conjurrc_contents(account, hostname, cert):
+    with open(f"{DEFAULT_CONFIG_FILE}", 'r') as conjurrc:
+        lines = conjurrc.readlines()
+        assert "---" in lines[0]
+        assert f"account: {account}" in lines[1]
+        assert f"appliance_url: {hostname}" in lines[2]
+        assert f"cert_file: {cert}" in lines[3]
+        assert f"plugins: []" in lines[4]
 
  # *************** VARIABLE ***************
 


### PR DESCRIPTION
### What does this PR do?
The purpose of this PR is to enhance the UX for the user when running in insecure mode. Previously the user would have to physically create the conjurrc file if they wanted to run the init in insecure mode b/c the command didnt support this flag. This addition allows the user to run init in insecure mode and get a blank value for the cert_file entry, creating the following conjurrc

```
---
account: cucumber
appliance_url: https://ec2-3-126-247-26.eu-central-1.compute.amazonaws.com
cert_file: ''
plugins: []
```
### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation