### PR TITLE
Fixes the bug where an empty cert_file entry allows for a user to login

### DIFF
--- a/conjur/logic/login_logic.py
+++ b/conjur/logic/login_logic.py
@@ -38,8 +38,13 @@ class LoginLogic:
 
         if ssl_verify is False:
             certificate_path = False
-        elif credential_data.machine.startswith("https"):
-            certificate_path = conjurrc.cert_file
+        elif ssl_verify and credential_data.machine.startswith("https"):
+            # Catches the case where a user does not run in insecure mode but the
+            # .conjurrc cert_file entry is empty
+            if conjurrc.cert_file == '':
+                certificate_path = True
+            else:
+                certificate_path = conjurrc.cert_file
 
         # pylint: disable=logging-fstring-interpolation
         logging.debug(f"Attempting to fetch '{credential_data.login}' API key from Conjur")

--- a/conjur/wrapper/http_wrapper.py
+++ b/conjur/wrapper/http_wrapper.py
@@ -28,6 +28,8 @@ class HttpVerb(Enum):
 
 
 #pylint: disable=too-many-locals
+# ssl_verify can accept Boolean or String as per requests docs
+# https://requests.readthedocs.io/en/master/api/#main-interface
 def invoke_endpoint(http_verb, endpoint, params, *args, check_errors=True,
                     ssl_verify=True, auth=None, api_token=None, query=None):
     """


### PR DESCRIPTION
### What does this PR do?
When a user runs in insecure mode, the conjurrc looked like:

```
---
account: cucumber
appliance_url: https://conjur-server
cert_file: ''
plugins: []
```
When they send a follow-up login command, the empty cert_file was being translated to FALSE. We don't want to make this implicit conclusion and only run in insecure mode if the user declares to do so
