### PR TITLE
Add support for CA signed certificates

### DIFF
--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -13,7 +13,7 @@ import logging
 # Internals
 import netrc
 
-from conjur.errors import OperationNotCompletedException
+from conjur.errors import InvalidOperationException
 from conjur.util import util_functions
 from conjur.api import Api
 from conjur.config import Config as ApiConfig
@@ -90,16 +90,16 @@ class Client():
                 # Raise exception if the client was initialized in insecure mode
                 # but a follow-up request is run without the insecure flag
                 if ssl_verify is True and loaded_config['ca_bundle'] == '':
-                    raise OperationNotCompletedException(cause="The client was initialized without certificate verification, "
-                                        "even though the command was ran with certificate verification enabled. ",
+                    raise InvalidOperationException(cause="The client was initialized without certificate verification, "
+                                        "even though the command was ran with certificate verification enabled.",
                                         solution="To continue communicating with the server insecurely, run the command "
-                                        "again with the --insecure flag. Otherwise, reinitialize the client.")
+                                        "again with the --insecure flag. Otherwise, reinitialize the client`")
 
                 logging.debug("Fetched connection details: "
                               f"{{'account': {loaded_config['account']}, "
                               f"'appliance_url': {loaded_config['url']}, "
                               f"'cert_file': {loaded_config['ca_bundle']}}}")
-            except OperationNotCompletedException:
+            except InvalidOperationException:
                 raise
             # TODO add error handling for when conjurrc field doesn't exist
             except Exception as exc:

--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -51,7 +51,7 @@ class Client():
 
     # The method signature is long but we want to explicitly control
     # what parameters are allowed
-    # pylint: disable=too-many-arguments,too-many-locals
+    # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     def __init__(self,
                  account=None,
                  api_key=None,
@@ -87,12 +87,11 @@ class Client():
                     if field_value:
                         on_disk_config[field_name] = field_value
                 loaded_config = on_disk_config
-
                 # Raise exception if the client was initialized in insecure mode
                 # but a follow-up request is run without the insecure flag
                 if ssl_verify is True and loaded_config['ca_bundle'] == '':
                     raise OperationNotCompletedException(cause="The client was initialized without certificate verification, "
-                                        "even though the command was ran with certificate verification turned on. ",
+                                        "even though the command was ran with certificate verification enabled. ",
                                         solution="To continue communicating with the server insecurely, run the command "
                                         "again with the --insecure flag. Otherwise, reinitialize the client.")
 
@@ -100,7 +99,8 @@ class Client():
                               f"{{'account': {loaded_config['account']}, "
                               f"'appliance_url': {loaded_config['url']}, "
                               f"'cert_file': {loaded_config['ca_bundle']}}}")
-
+            except OperationNotCompletedException:
+                raise
             # TODO add error handling for when conjurrc field doesn't exist
             except Exception as exc:
                 raise ConfigException(exc) from exc

--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -13,15 +13,12 @@ import logging
 # Internals
 import netrc
 
+from conjur.errors import OperationNotCompletedException
 from conjur.util import util_functions
 from conjur.api import Api
-from conjur.api.ssl_client import SSLClient
 from conjur.config import Config as ApiConfig
 from conjur.constants import DEFAULT_NETRC_FILE
-from conjur.controller import InitController
-from conjur.logic import InitLogic
 from conjur.util import CredentialsFromFile
-from conjur.data_object import ConjurrcData
 from conjur.resource import Resource
 
 
@@ -39,7 +36,7 @@ class ConfigException(Exception):
     SDK in their code.
     """
 
-
+# pylint: disable=logging-fstring-interpolation,line-too-long
 class Client():
     """
     Client
@@ -90,7 +87,15 @@ class Client():
                     if field_value:
                         on_disk_config[field_name] = field_value
                 loaded_config = on_disk_config
-                # pylint: disable=logging-fstring-interpolation
+
+                # Raise exception if the client was initialized in insecure mode
+                # but a follow-up request is run without the insecure flag
+                if ssl_verify is True and loaded_config['ca_bundle'] == '':
+                    raise OperationNotCompletedException(cause="The client was initialized without certificate verification, "
+                                        "even though the command was ran with certificate verification turned on. ",
+                                        solution="To continue communicating with the server insecurely, run the command "
+                                        "again with the --insecure flag. Otherwise, reinitialize the client.")
+
                 logging.debug("Fetched connection details: "
                               f"{{'account': {loaded_config['account']}, "
                               f"'appliance_url': {loaded_config['url']}, "
@@ -145,27 +150,6 @@ class Client():
             logging.basicConfig(level=logging.DEBUG, format=self.LOGGING_FORMAT)
         else:
             logging.basicConfig(level=logging.WARN, format=self.LOGGING_FORMAT)
-
-    # Technical debt: refactor when time permits because this function
-    # doesn't belong here
-    @staticmethod
-    def initialize(url, account, cert, force, ssl_verify):
-        """
-        Initializes the client, creating the .conjurrc file
-        """
-        ssl_service = SSLClient()
-
-        conjurrc_data = ConjurrcData(url,
-                                     account,
-                                     cert)
-
-        init_logic = InitLogic(ssl_service)
-
-        input_controller = InitController(conjurrc_data,
-                                          init_logic,
-                                          force,
-                                          ssl_verify)
-        input_controller.load()
 
     ### API passthrough
 

--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -43,6 +43,8 @@ class InitController:
         """
         if self.ssl_verify is True:
             fetched_certificate = self.get_server_certificate()
+            # For a uniform experience, regardless if the certificate is self-signed
+            # or CA-signed, we will write the certificate on the machine
             self.write_certificate(fetched_certificate)
         else:
             self.conjurrc_data.cert_file=""

--- a/conjur/controller/login_controller.py
+++ b/conjur/controller/login_controller.py
@@ -12,7 +12,7 @@ import getpass
 import logging
 import sys
 
-from conjur.errors import OperationNotCompletedException
+from conjur.errors import InvalidOperationException
 from conjur.util import util_functions
 from conjur.constants import CREDENTIAL_HOST_PATH, DEFAULT_NETRC_FILE
 from conjur.data_object.conjurrc_data import ConjurrcData
@@ -88,6 +88,7 @@ class LoginController:
 
         return conjurrc
 
+    # pylint: disable=line-too-long
     def get_api_key(self, conjurrc):
         """
         Method to fetch the user/host's API key from Conjur which is to be added to the netrc
@@ -97,8 +98,11 @@ class LoginController:
                                                                         self.credential_data,
                                                                         self.user_password,
                                                                         conjurrc)
-        except OperationNotCompletedException:
-            raise
+        except InvalidOperationException as invalid_operation:
+            raise InvalidOperationException(cause="The client was initialized without certificate verification, "
+                                                  "even though the command was ran with certificate verification enabled.",
+                                            solution="To continue communicating with the server insecurely, run the command "
+                                                     "again with the --insecure flag. Otherwise, reinitialize the client.") from invalid_operation
         except Exception as error:
             raise RuntimeError("Failed to log in to Conjur. Unable to authenticate with Conjur. "
                 f"Reason: {error}. Check your credentials and try again.") from error

--- a/conjur/controller/login_controller.py
+++ b/conjur/controller/login_controller.py
@@ -12,6 +12,7 @@ import getpass
 import logging
 import sys
 
+from conjur.errors import OperationNotCompletedException
 from conjur.util import util_functions
 from conjur.constants import CREDENTIAL_HOST_PATH, DEFAULT_NETRC_FILE
 from conjur.data_object.conjurrc_data import ConjurrcData
@@ -96,6 +97,8 @@ class LoginController:
                                                                         self.credential_data,
                                                                         self.user_password,
                                                                         conjurrc)
+        except OperationNotCompletedException:
+            raise
         except Exception as error:
             raise RuntimeError("Failed to log in to Conjur. Unable to authenticate with Conjur. "
                 f"Reason: {error}. Check your credentials and try again.") from error

--- a/conjur/controller/user_controller.py
+++ b/conjur/controller/user_controller.py
@@ -40,7 +40,6 @@ class UserController():
         except OperationNotCompletedException:
             sys.stdout.write("An error occurred. Log in again or try again in debug mode.\n")
             raise
-            # pylint: disable=line-too-long
 
     # pylint: disable=logging-fstring-interpolation,line-too-long
     def change_personal_password(self):

--- a/conjur/errors.py
+++ b/conjur/errors.py
@@ -20,8 +20,8 @@ class OperationNotCompletedException(Exception):
     Exception for when an operation was not completed successfully
     and CLI is left in instable state
     """
-    def __init__(self, message="Error: Failed to run command to completion."):
-        self.message = message
+    def __init__(self, cause="", solution=""):
+        self.message = "Error: Failed to run command to completion. " + cause + solution
         super().__init__(self.message)
 
 class MissingRequiredParameterException(Exception):

--- a/conjur/errors.py
+++ b/conjur/errors.py
@@ -6,9 +6,6 @@ Error module
 This module holds all CLI-specific errors
 """
 
-class InvalidOperationException(Exception):
-    """ Exception for invalid user operations """
-
 class InvalidPasswordComplexityException(Exception):
     """
     Exception for when the user supplies a not complex enough password when
@@ -21,7 +18,15 @@ class OperationNotCompletedException(Exception):
     and CLI is left in instable state
     """
     def __init__(self, cause="", solution=""):
-        self.message = "Error: Failed to run command to completion. " + cause + solution
+        self.message = f"Error: Failed to run command to completion. Reason: {cause} {solution}"
+        super().__init__(self.message)
+
+class InvalidOperationException(Exception):
+    """
+    Exception for when the operation performed was invalid
+    """
+    def __init__(self, cause="", solution=""):
+        self.message = f"Error: Invalid operation. Reason: {cause} {solution}"
         super().__init__(self.message)
 
 class MissingRequiredParameterException(Exception):

--- a/conjur/logic/init_logic.py
+++ b/conjur/logic/init_logic.py
@@ -41,7 +41,7 @@ class InitLogic:
             fingerprint, readable_certificate = self.ssl_service.get_certificate(hostname, port)
             logging.debug("Successfully fetched certificate")
         except Exception as error:
-            raise Exception(f"Unable to retrieve certificate from {hostname}:{port}. " \
+            raise Exception(f"Unable to retrieve certificate from {hostname}:{port}. "
                             f"Reason: {str(error)}") from error
 
         return fingerprint, readable_certificate
@@ -71,7 +71,7 @@ class InitLogic:
         conjurrc_data.account = response['configuration']['conjur']['account']
 
         # pylint: disable=logging-fstring-interpolation
-        logging.debug(f"Account '{conjurrc_data.account}' "\
+        logging.debug(f"Account '{conjurrc_data.account}' "
                       "successfully fetched from the Conjur server")
 
     @classmethod
@@ -104,7 +104,7 @@ class InitLogic:
 
             # Ensures that there are no None fields written to conjurrc
             for attr,value in conjurrc_data.__dict__.items():
-                _pretty_print_object[str(attr)]=value
+                _pretty_print_object[str(attr)] = value
 
             config_fp.write("---\n")
             yaml.dump(_pretty_print_object, config_fp)

--- a/conjur/logic/login_logic.py
+++ b/conjur/logic/login_logic.py
@@ -45,7 +45,7 @@ class LoginLogic:
             # .conjurrc cert_file entry is empty
             if conjurrc.cert_file == '' and ssl_verify:
                 raise OperationNotCompletedException(cause="The client was initialized without certificate verification, "
-                                    "even though the command was ran with certificate verification turned on. ",
+                                    "even though the command was ran with certificate verification enabled. ",
                                     solution="To continue communicating with the server insecurely, run the command "
                                     "again with the --insecure flag. Otherwise, reinitialize the client.")
 

--- a/conjur/logic/login_logic.py
+++ b/conjur/logic/login_logic.py
@@ -12,7 +12,7 @@ import logging
 
 # Internals
 from conjur.api.endpoints import ConjurEndpoint
-from conjur.errors import OperationNotCompletedException
+from conjur.errors import InvalidOperationException
 from conjur.wrapper.http_wrapper import invoke_endpoint, HttpVerb
 
 class LoginLogic:
@@ -44,10 +44,7 @@ class LoginLogic:
             # Catches the case where a user does not run in insecure mode but the
             # .conjurrc cert_file entry is empty
             if conjurrc.cert_file == '' and ssl_verify:
-                raise OperationNotCompletedException(cause="The client was initialized without certificate verification, "
-                                    "even though the command was ran with certificate verification enabled. ",
-                                    solution="To continue communicating with the server insecurely, run the command "
-                                    "again with the --insecure flag. Otherwise, reinitialize the client.")
+                raise InvalidOperationException
 
             certificate_path = conjurrc.cert_file
 

--- a/conjur/logic/login_logic.py
+++ b/conjur/logic/login_logic.py
@@ -12,6 +12,7 @@ import logging
 
 # Internals
 from conjur.api.endpoints import ConjurEndpoint
+from conjur.errors import OperationNotCompletedException
 from conjur.wrapper.http_wrapper import invoke_endpoint, HttpVerb
 
 class LoginLogic:
@@ -27,6 +28,7 @@ class LoginLogic:
         self.credentials_storage = credentials_storage
 
     @classmethod
+    # pylint: disable=line-too-long,logging-fstring-interpolation
     def get_api_key(cls, ssl_verify, credential_data, password, conjurrc):
         """
         Method to fetch the user/host's API key from Conjur
@@ -41,10 +43,13 @@ class LoginLogic:
         elif ssl_verify and credential_data.machine.startswith("https"):
             # Catches the case where a user does not run in insecure mode but the
             # .conjurrc cert_file entry is empty
-            if conjurrc.cert_file == '':
-                certificate_path = True
-            else:
-                certificate_path = conjurrc.cert_file
+            if conjurrc.cert_file == '' and ssl_verify:
+                raise OperationNotCompletedException(cause="The client was initialized without certificate verification, "
+                                    "even though the command was ran with certificate verification turned on. ",
+                                    solution="To continue communicating with the server insecurely, run the command "
+                                    "again with the --insecure flag. Otherwise, reinitialize the client.")
+
+            certificate_path = conjurrc.cert_file
 
         # pylint: disable=logging-fstring-interpolation
         logging.debug(f"Attempting to fetch '{credential_data.login}' API key from Conjur")

--- a/conjur/wrapper/http_wrapper.py
+++ b/conjur/wrapper/http_wrapper.py
@@ -52,6 +52,9 @@ def invoke_endpoint(http_verb, endpoint, params, *args, check_errors=True,
 
     request_method = getattr(requests, http_verb.name.lower())
 
+    # By default, on each request the certificate will be verified. If there is
+    # a failure in verification, the fallback solution will be passing in the
+    # server pem received during initialization of the client
     #pylint: disable=not-callable
     try:
         response = request_method(url, *args,
@@ -74,9 +77,9 @@ def invoke_endpoint(http_verb, endpoint, params, *args, check_errors=True,
             response.raise_for_status()
         except requests.exceptions.HTTPError as http_error:
             if response.text:
-                logging.debug(requests.exceptions.HTTPError(f'{http_error.response.status_code}'
-                                                            f' {http_error.response.reason}'
-                                                            f' {response.text}'))
+                logging.debug(requests.exceptions.HTTPError(f"{http_error.response.status_code}"
+                                                            f" {http_error.response.reason}"
+                                                            f" {response.text}"))
             raise http_error
         except Exception as general_error:
             raise general_error

--- a/test/test_config/no_cert_conjurrc
+++ b/test/test_config/no_cert_conjurrc
@@ -1,5 +1,5 @@
 ---
 account: dev
 appliance_url: https://conjur-https
-cert_file:
+cert_file: ''
 plugins: []

--- a/test/test_integration_credentials.py
+++ b/test/test_integration_credentials.py
@@ -13,7 +13,6 @@ import shutil
 import string
 from contextlib import redirect_stderr
 from unittest.mock import patch
-
 import requests
 
 from test.util.test_infrastructure import integration_test
@@ -66,8 +65,9 @@ class CliIntegrationTestCredentials(IntegrationTestCaseBase):
     @integration_test(True)
     def test_cli_configured_in_insecure_mode_but_run_in_secure_mode_raises_error(self):
         shutil.copy(self.environment.path_provider.test_insecure_conjurrc_file_path, self.environment.path_provider.conjurrc_path)
-        self.invoke_cli(self.cli_auth_params,
-                        ['login', '-i', 'admin', '-p', self.client_params.env_api_key], exit_code=1)
+        output = self.invoke_cli(self.cli_auth_params,
+                            ['login', '-i', 'admin', '-p', self.client_params.env_api_key], exit_code=1)
+        self.assertIn("Error: Invalid operation. Reason: The client was initialized without", output)
 
     '''
     Validates that if a user configures the CLI in insecure mode and runs a command in 

--- a/test/test_integration_credentials.py
+++ b/test/test_integration_credentials.py
@@ -7,8 +7,11 @@ This test file handles the login/logout test flows when running
 `conjur login`/`conjur logout`
 """
 import base64
+import io
 import os
+import shutil
 import string
+from contextlib import redirect_stderr
 from unittest.mock import patch
 
 import requests
@@ -54,7 +57,31 @@ class CliIntegrationTestCredentials(IntegrationTestCaseBase):
             netrc_test.write(f"login {login}\n")
             netrc_test.write(f"password {password}\n")
 
-    # *************** INITIAL LOGIN CREDENTIALS TESTS ***************
+    # *************** LOGIN CREDENTIALS TESTS ***************
+
+    '''
+    Validates that if a user configures the CLI in insecure mode and runs the command not in 
+    insecure mode, then they will fail
+    '''
+    @integration_test(True)
+    def test_cli_configured_in_insecure_mode_but_run_in_secure_mode_raises_error(self):
+        shutil.copy(self.environment.path_provider.test_insecure_conjurrc_file_path, self.environment.path_provider.conjurrc_path)
+        self.invoke_cli(self.cli_auth_params,
+                        ['login', '-i', 'admin', '-p', self.client_params.env_api_key], exit_code=1)
+
+    '''
+    Validates that if a user configures the CLI in insecure mode and runs a command in 
+    insecure mode, then they will succeed
+    '''
+    @integration_test()
+    def test_cli_configured_in_insecure_mode_and_run_in_insecure_mode_passes(self):
+        capture_stream = io.StringIO()
+        shutil.copy(self.environment.path_provider.test_insecure_conjurrc_file_path, self.environment.path_provider.conjurrc_path)
+
+        with redirect_stderr(capture_stream):
+            self.invoke_cli(self.cli_auth_params,
+                            ['--insecure', 'login', '-i', 'admin', '-p', self.client_params.env_api_key])
+        self.assertIn('InsecureRequestWarning', capture_stream.getvalue())
 
     '''
     Validates a user can log in with a password, instead of their API key

--- a/test/test_unit_cli.py
+++ b/test/test_unit_cli.py
@@ -222,7 +222,7 @@ Copyright (c) 2021 CyberArk Software Ltd. All rights reserved.
         Cli().handle_login_logic(identifier='someidentifier', password='somepassword', ssl_verify=True)
         mock_load.assert_called_once()
 
-    @patch.object(Client, 'initialize')
+    @patch.object(Cli, 'handle_init_logic')
     def test_cli_init_functions_are_properly_called(self, mock_init):
         Cli().handle_init_logic(url="https://someurl", name="somename", certificate="/path/to/pem", force=False)
         mock_init.assert_called_once()

--- a/test/test_unit_cli.py
+++ b/test/test_unit_cli.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from conjur import Client
+from conjur.controller import InitController
 from conjur.controller.host_controller import HostController
 from conjur.controller.login_controller import LoginController
 from conjur.controller.logout_controller import LogoutController
@@ -217,15 +218,20 @@ Copyright (c) 2021 CyberArk Software Ltd. All rights reserved.
     def test_cli_invokes_whoami_outputs_formatted_json(self, cli_invocation, output, client):
         self.assertEquals('{\n    "account": "myaccount"\n}\n', output)
 
+    @patch.object(Cli, 'handle_init_logic')
+    def test_cli_init_functions_are_properly_called(self, mock_init):
+        Cli().handle_init_logic(url="https://someurl", account="somename", cert="/path/to/pem", force=False)
+        mock_init.assert_called_once()
+
+    @patch.object(InitController, 'load')
+    def test_cli_init_load_function_is_properly_called(self, mock_load):
+        Cli().handle_init_logic(url="https://someurl", account="somename", cert="/path/to/pem", force=False, ssl_verify=True)
+        mock_load.assert_called_once()
+
     @patch.object(LoginController, 'load')
     def test_cli_login_functions_are_properly_called(self, mock_load):
         Cli().handle_login_logic(identifier='someidentifier', password='somepassword', ssl_verify=True)
         mock_load.assert_called_once()
-
-    @patch.object(Cli, 'handle_init_logic')
-    def test_cli_init_functions_are_properly_called(self, mock_init):
-        Cli().handle_init_logic(url="https://someurl", name="somename", certificate="/path/to/pem", force=False)
-        mock_init.assert_called_once()
 
     @patch.object(LogoutController, 'remove_credentials')
     def test_cli_logout_functions_are_properly_called(self, mock_remove_creds):

--- a/test/test_unit_client.py
+++ b/test/test_unit_client.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, MagicMock
 from conjur.api.client import ConfigException, Client
 
 # CredentialsFromFile mocked class
-from conjur.errors import OperationNotCompletedException
+from conjur.errors import InvalidOperationException
 
 MockCredentials = {
     'login_id': 'apiconfigloginid',
@@ -106,7 +106,7 @@ class ClientTest(unittest.TestCase):
 
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfigNoCert())
     def test_client_can_raise_incomplete_operation_error_if_ssl_modes_are_conflicting(self, mock_config):
-        with self.assertRaises(OperationNotCompletedException):
+        with self.assertRaises(InvalidOperationException):
             Client(ssl_verify=True)
 
     @patch('conjur.api.client.Api')

--- a/test/test_unit_client.py
+++ b/test/test_unit_client.py
@@ -7,11 +7,12 @@ from unittest.mock import patch, MagicMock
 from conjur.api.client import ConfigException, Client
 
 # CredentialsFromFile mocked class
+from conjur.errors import OperationNotCompletedException
+
 MockCredentials = {
     'login_id': 'apiconfigloginid',
     'api_key': 'apiconfigapikey',
 }
-
 
 # ApiConfig mocking class
 class MockApiConfig(object):
@@ -22,6 +23,20 @@ class MockApiConfig(object):
         'url': 'apiconfigurl',
         'account': 'apiconfigaccount',
         'ca_bundle': 'apiconfigcabundle',
+    }
+
+    def __iter__(self):
+        return iter(self.CONFIG.items())
+
+# ApiConfig mocking class
+class MockApiConfigNoCert(object):
+    CONFIG = {
+        'key1': 'value1',
+        'key2': 'value2',
+
+        'url': 'apiconfigurl',
+        'account': 'apiconfigaccount',
+        'ca_bundle': '',
     }
 
     def __iter__(self):
@@ -48,44 +63,6 @@ class ClientTest(unittest.TestCase):
     # To run properly, we need to configure the loaded conjurrc
 
     ### Init configuration tests ###
-
-    # def test_client_passes_init_parameters(self):
-    #     client = Client
-    #     client.initialize = MagicMock()
-    #     Client.initialize('https://someurl', 'someaccount', None, False)
-    #     client.initialize.assert_called_once_with('https://someurl', 'someaccount', None, False)
-    #
-    # def test_client_passes_init_all_parameters_provided(self):
-    #     client = Client
-    #     client.initialize = MagicMock()
-    #     Client.initialize('https://someurl', 'someaccount', "somecert.pem", False)
-    #     client.initialize.assert_called_once_with('https://someurl', 'someaccount', "somecert.pem", False)
-    #
-    # def test_client_passes_init_parameters_with_url_account_provided(self):
-    #     client = Client
-    #     client.initialize = MagicMock()
-    #     Client.initialize('https://someurl', 'someaccount', None, True)
-    #     client.initialize.assert_called_once_with('https://someurl', 'someaccount', None, True)
-    #
-    # def test_client_passes_init_parameters_with_provided_account(self):
-    #     client = Client
-    #     client.initialize = MagicMock()
-    #     Client.initialize(None, 'someaccount', None, False)
-    #     client.initialize.assert_called_once_with(None, 'someaccount', None, False)
-    #
-    # def test_client_passes_init_parameters_with_none_provided(self):
-    #     client = Client
-    #     client.initialize = MagicMock()
-    #     Client.initialize(None, None, None, False)
-    #     client.initialize.assert_called_once_with(None, None, None, False)
-
-    # @patch('conjur.api.client.ApiConfig', new=MissingMockApiConfig)
-    # def test_client_init_initialize_calls_load_properly(self):
-    #     client = Client
-    #     mock_init_controller = InitController
-    #     mock_init_controller.load = MagicMock()
-    #     Client.initialize('someurl', 'someaccount', '/some/path/to/pem', False, True)
-    #     mock_init_controller.load.assert_called_once()
 
     @patch('conjur.api.client.ApiConfig', new=MissingMockApiConfig)
     def test_client_throws_error_when_no_config(self):
@@ -126,6 +103,11 @@ class ClientTest(unittest.TestCase):
     def test_client_can_raise_netrc_exception_error(self, mock_cred, mock_api_instance):
         with self.assertRaises(Exception):
             Client(url='https://myurl', account='myacct', login_id='mylogin', ca_bundle="mybundle", ssl_verify=False)
+
+    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfigNoCert())
+    def test_client_can_raise_incomplete_operation_error_if_ssl_modes_are_conflicting(self, mock_config):
+        with self.assertRaises(OperationNotCompletedException):
+            Client(ssl_verify=True)
 
     @patch('conjur.api.client.Api')
     def test_client_passes_default_account_to_api_initializer_if_none_is_provided(self, mock_api_instance):

--- a/test/test_unit_client.py
+++ b/test/test_unit_client.py
@@ -7,8 +7,6 @@ from unittest.mock import patch, MagicMock
 from conjur.api.client import ConfigException, Client
 
 # CredentialsFromFile mocked class
-from conjur.controller.init_controller import InitController
-
 MockCredentials = {
     'login_id': 'apiconfigloginid',
     'api_key': 'apiconfigapikey',
@@ -51,43 +49,43 @@ class ClientTest(unittest.TestCase):
 
     ### Init configuration tests ###
 
-    def test_client_passes_init_parameters(self):
-        client = Client
-        client.initialize = MagicMock()
-        Client.initialize('https://someurl', 'someaccount', None, False)
-        client.initialize.assert_called_once_with('https://someurl', 'someaccount', None, False)
+    # def test_client_passes_init_parameters(self):
+    #     client = Client
+    #     client.initialize = MagicMock()
+    #     Client.initialize('https://someurl', 'someaccount', None, False)
+    #     client.initialize.assert_called_once_with('https://someurl', 'someaccount', None, False)
+    #
+    # def test_client_passes_init_all_parameters_provided(self):
+    #     client = Client
+    #     client.initialize = MagicMock()
+    #     Client.initialize('https://someurl', 'someaccount', "somecert.pem", False)
+    #     client.initialize.assert_called_once_with('https://someurl', 'someaccount', "somecert.pem", False)
+    #
+    # def test_client_passes_init_parameters_with_url_account_provided(self):
+    #     client = Client
+    #     client.initialize = MagicMock()
+    #     Client.initialize('https://someurl', 'someaccount', None, True)
+    #     client.initialize.assert_called_once_with('https://someurl', 'someaccount', None, True)
+    #
+    # def test_client_passes_init_parameters_with_provided_account(self):
+    #     client = Client
+    #     client.initialize = MagicMock()
+    #     Client.initialize(None, 'someaccount', None, False)
+    #     client.initialize.assert_called_once_with(None, 'someaccount', None, False)
+    #
+    # def test_client_passes_init_parameters_with_none_provided(self):
+    #     client = Client
+    #     client.initialize = MagicMock()
+    #     Client.initialize(None, None, None, False)
+    #     client.initialize.assert_called_once_with(None, None, None, False)
 
-    def test_client_passes_init_all_parameters_provided(self):
-        client = Client
-        client.initialize = MagicMock()
-        Client.initialize('https://someurl', 'someaccount', "somecert.pem", False)
-        client.initialize.assert_called_once_with('https://someurl', 'someaccount', "somecert.pem", False)
-
-    def test_client_passes_init_parameters_with_url_account_provided(self):
-        client = Client
-        client.initialize = MagicMock()
-        Client.initialize('https://someurl', 'someaccount', None, True)
-        client.initialize.assert_called_once_with('https://someurl', 'someaccount', None, True)
-
-    def test_client_passes_init_parameters_with_provided_account(self):
-        client = Client
-        client.initialize = MagicMock()
-        Client.initialize(None, 'someaccount', None, False)
-        client.initialize.assert_called_once_with(None, 'someaccount', None, False)
-
-    def test_client_passes_init_parameters_with_none_provided(self):
-        client = Client
-        client.initialize = MagicMock()
-        Client.initialize(None, None, None, False)
-        client.initialize.assert_called_once_with(None, None, None, False)
-
-    @patch('conjur.api.client.ApiConfig', new=MissingMockApiConfig)
-    def test_client_init_initialize_calls_load_properly(self):
-        client = Client
-        mock_init_controller = InitController
-        mock_init_controller.load = MagicMock()
-        Client.initialize('someurl', 'someaccount', '/some/path/to/pem', False, True)
-        mock_init_controller.load.assert_called_once()
+    # @patch('conjur.api.client.ApiConfig', new=MissingMockApiConfig)
+    # def test_client_init_initialize_calls_load_properly(self):
+    #     client = Client
+    #     mock_init_controller = InitController
+    #     mock_init_controller.load = MagicMock()
+    #     Client.initialize('someurl', 'someaccount', '/some/path/to/pem', False, True)
+    #     mock_init_controller.load.assert_called_once()
 
     @patch('conjur.api.client.ApiConfig', new=MissingMockApiConfig)
     def test_client_throws_error_when_no_config(self):
@@ -129,7 +127,7 @@ class ClientTest(unittest.TestCase):
         with self.assertRaises(Exception):
             Client(url='https://myurl', account='myacct', login_id='mylogin', ca_bundle="mybundle", ssl_verify=False)
 
-    @patch('conjur.api.Api')
+    @patch('conjur.api.client.Api')
     def test_client_passes_default_account_to_api_initializer_if_none_is_provided(self, mock_api_instance):
         Client(url='http://myurl', login_id='mylogin', password='mypass',
                ca_bundle="mybundle")
@@ -290,19 +288,6 @@ class ClientTest(unittest.TestCase):
                password='mypass', debug=True)
 
         mock_logging.assert_called_once_with(format=Client.LOGGING_FORMAT, level=logging.DEBUG)
-
-    @patch('conjur.api.client.Api')
-    def test_client_passes_default_account_to_api_initializer_if_none_is_provided(self, mock_api_instance):
-        Client(url='http://myurl', login_id='mylogin', password='mypass',
-               ca_bundle="mybundle")
-
-        mock_api_instance.assert_called_with(
-            account='default',
-            ca_bundle='mybundle',
-            http_debug=False,
-            ssl_verify=True,
-            url='http://myurl',
-        )
 
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.util.credentials_from_file.CredentialsFromFile.load', return_value=MockCredentials)

--- a/test/test_unit_login_controller.py
+++ b/test/test_unit_login_controller.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from conjur.errors import OperationNotCompletedException
+from conjur.errors import OperationNotCompletedException, InvalidOperationException
 from conjur.util import util_functions
 from conjur.data_object.credentials_data import CredentialsData
 from conjur.controller.login_controller import LoginController
@@ -86,9 +86,9 @@ class LoginControllerTest(unittest.TestCase):
 
     @patch('conjur.logic.login_logic')
     def test_login_get_api_can_raise_operation_not_completed_exception(self, mock_logic):
-        mock_logic.get_api_key = MagicMock(side_effect=OperationNotCompletedException)
+        mock_logic.get_api_key = MagicMock(side_effect=InvalidOperationException)
         mock_login_controller = LoginController(True, None, MockCredentialsData, mock_logic)
-        with self.assertRaises(OperationNotCompletedException):
+        with self.assertRaises(InvalidOperationException):
             mock_login_controller.get_api_key('someconjurrc')
 
     def test_login_raises_error_when_error_occurred_while_getting_api_key(self):

--- a/test/test_unit_login_controller.py
+++ b/test/test_unit_login_controller.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from conjur.errors import OperationNotCompletedException
 from conjur.util import util_functions
 from conjur.data_object.credentials_data import CredentialsData
 from conjur.controller.login_controller import LoginController
@@ -82,6 +83,13 @@ class LoginControllerTest(unittest.TestCase):
                                                            MockCredentialsData,
                                                            mock_login_controller.user_password,
                                                            MockConjurrc)
+
+    @patch('conjur.logic.login_logic')
+    def test_login_get_api_can_raise_operation_not_completed_exception(self, mock_logic):
+        mock_logic.get_api_key = MagicMock(side_effect=OperationNotCompletedException)
+        mock_login_controller = LoginController(True, None, MockCredentialsData, mock_logic)
+        with self.assertRaises(OperationNotCompletedException):
+            mock_login_controller.get_api_key('someconjurrc')
 
     def test_login_raises_error_when_error_occurred_while_getting_api_key(self):
         with patch('conjur.logic.login_logic') as mock_logic:

--- a/test/test_unit_login_logic.py
+++ b/test/test_unit_login_logic.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from conjur.errors import OperationNotCompletedException
+from conjur.errors import InvalidOperationException
 from conjur.util.credentials_from_file import CredentialsFromFile
 from conjur.api.endpoints import ConjurEndpoint
 from conjur.wrapper.http_wrapper import HttpVerb
@@ -61,6 +61,6 @@ class LoginLogicTest(unittest.TestCase):
                                                      ssl_verify='some/path/to/pem')
 
     def test_empty_cert_file_entry_and_ssl_verify_enabled(self):
-        with self.assertRaises(OperationNotCompletedException):
+        with self.assertRaises(InvalidOperationException):
             mock_login_logic = LoginLogic(MockCredentialsData)
             mock_login_logic.get_api_key(True, MockCredentialsData, 'somepass', MockConjurrcEmptyCertEntry)

--- a/test/test_unit_login_logic.py
+++ b/test/test_unit_login_logic.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+from conjur.errors import OperationNotCompletedException
 from conjur.util.credentials_from_file import CredentialsFromFile
 from conjur.api.endpoints import ConjurEndpoint
 from conjur.wrapper.http_wrapper import HttpVerb
@@ -15,6 +16,12 @@ class MockConjurrc:
     appliance_url = 'https://someurl'
     account = 'someacc'
     cert_file = 'some/path/to/pem'
+    plugins: []
+
+class MockConjurrcEmptyCertEntry:
+    appliance_url = 'https://someurl'
+    account = 'someacc'
+    cert_file = ''
     plugins: []
 
 class MockClientResponse():
@@ -52,3 +59,8 @@ class LoginLogicTest(unittest.TestCase):
                                                      params,
                                                      auth=('somelogin', 'somepass'),
                                                      ssl_verify='some/path/to/pem')
+
+    def test_empty_cert_file_entry_and_ssl_verify_enabled(self):
+        with self.assertRaises(OperationNotCompletedException):
+            mock_login_logic = LoginLogic(MockCredentialsData)
+            mock_login_logic.get_api_key(True, MockCredentialsData, 'somepass', MockConjurrcEmptyCertEntry)

--- a/test/test_unit_logout_logic.py
+++ b/test/test_unit_logout_logic.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock
 
 from conjur.util.credentials_from_file import CredentialsFromFile
 from conjur.logic.logout_logic import LogoutLogic
@@ -11,8 +12,6 @@ class LogoutLogicTest(unittest.TestCase):
 
         self.assertEquals(mock_logout_logic.credentials, mock_credentials)
 
-    #TODO: Fix test broke during refactor
-    """
     def test_logout_remove_credentials_calls_remove_credentials(self):
         mock_credentials = CredentialsFromFile
         mock_logout_logic = LogoutLogic(mock_credentials)
@@ -20,4 +19,3 @@ class LogoutLogicTest(unittest.TestCase):
 
         mock_logout_logic.remove_credentials("someurl")
         mock_credentials.remove_credentials.assert_called_once_with("someurl")
-    """

--- a/test/test_unit_user_controller.py
+++ b/test/test_unit_user_controller.py
@@ -27,6 +27,13 @@ class UserControllerTest(unittest.TestCase):
         with self.assertRaises(OperationNotCompletedException):
             user_controller.rotate_api_key()
 
+    @patch('conjur.logic.user_logic')
+    def test_login_rotate_api_key_can_raise_operation_not_completed_exception(self, mock_user_logic):
+        mock_user_logic.rotate_api_key = MagicMock(side_effect=OperationNotCompletedException)
+        mock_user_controller = UserController(mock_user_logic, self.user_input_data)
+        with self.assertRaises(OperationNotCompletedException):
+            mock_user_controller.rotate_api_key()
+
     def test_change_password_can_raise_authn_error(self):
         # mock the status code of the error received
         mock_response = MagicMock()

--- a/test/test_unit_user_logic.py
+++ b/test/test_unit_user_logic.py
@@ -37,8 +37,6 @@ class UserLogicTest(unittest.TestCase):
         self.assertEquals(user_logic.credentials_from_store, mock_credentials_from_store)
         self.assertEquals(user_logic.client, mock_client)
 
-    # TODO: Fix test broken during refactor
-    """
     '''
     Validate that if user doesn't provide username, rotate_other_api_key will be called once with proper params
     '''
@@ -48,10 +46,7 @@ class UserLogicTest(unittest.TestCase):
         self.user_logic.rotate_other_api_key = MagicMock(return_value='someAPIKey')
         self.user_logic.rotate_api_key('someUserToRotate')
         self.user_logic.rotate_other_api_key.assert_called_once_with('someUserToRotate')
-    """
 
-    # TODO: Fix test broken during refactor
-    """
     '''
     Validate that if user doesn't provide username, rotate_personal_api_key will be called once with proper params
     '''
@@ -63,10 +58,7 @@ class UserLogicTest(unittest.TestCase):
         self.user_logic.rotate_personal_api_key.assert_called_once_with('someuser',
                                                                         {'login_id': 'someuser', 'api_key':'someAPIKey'},
                                                                         'someAPIKey')
-    """
 
-    # TODO: Fix the test broken during refactoring
-    """
     def test_change_password_returns_user(self):
         with patch.object(UserLogic, 'extract_credentials_from_credential_store', return_value={'login_id': 'someuser', 'api_key':'someAPIKey'}):
             client = MagicMock(return_value=None)
@@ -74,7 +66,6 @@ class UserLogicTest(unittest.TestCase):
             mock_user_logic.client.change_personal_password = MagicMock(return_value='success!')
             resource_to_update, _ = mock_user_logic.change_personal_password('someNewPassword')
             self.assertEquals(resource_to_update, 'someuser')
-    """
 
     @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file', return_value=MockConjurrc)
     def test_extract_credentials_from_store_returns_netrc_store(self, mock_conjurrc):

--- a/test/util/test_helpers.py
+++ b/test/util/test_helpers.py
@@ -81,10 +81,6 @@ def print_instead_of_raise_error(self, variable_id, error_message_regex):
 
  # *************** POLICY ***************
 
-def load_policy(self, policy_path):
-    return self.invoke_cli(self.cli_auth_params,
-                           ['policy', 'load', '-b', 'root', '-f', policy_path])
-
 def generate_policy_string(self):
         variable_1 = 'simple/basic/{}'.format(uuid.uuid4().hex)
         variable_2 = 'simple/space filled/{}'.format(uuid.uuid4().hex)

--- a/test/util/test_path_provider.py
+++ b/test/util/test_path_provider.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 # Internals
@@ -48,6 +47,10 @@ class TestRunnerPathProvider():  # pragma: no cover
         return os.path.join(self.ROOT_DIR, self.conjurrc_file_name)
 
     @property
+    def test_insecure_conjurrc_file_path(self):
+        return os.path.join(self.HELPERS_FILES_DIR, "test_config", "no_cert_conjurrc")
+
+    @property
     def netrc_path(self):
         return os.path.join(self.ROOT_DIR, self.netrc_file_name)
 
@@ -85,8 +88,3 @@ class TestRunnerPathProvider():  # pragma: no cover
 
     def get_policy_path(self, type: str):
         return os.path.join(self.HELPERS_FILES_DIR, "test_config", f"{type}_policy.yml")
-
-    @property
-    def test_conjurrc_file_path(self):
-        return os.path.join(self.HELPERS_FILES_DIR, "test_config", "conjurrc")
-


### PR DESCRIPTION
### What does this PR do?
When using the CLI in an environment with signed certificates, we are successful in running init, saving the pem to the machine received from the Conjur server and generating the conjurrc. Upon sending a follow-up request (login), the request is failing on CERTIFICATE_VERIFY_FAILED error. This fix adds the signed-certificate flow

At this time we will not add the CA cert flow to our testing infrastructure. There is a [separate ticket for this](https://github.com/cyberark/conjur-api-python3/issues/200)
### What ticket does this PR close?
Resolves #178 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
Will be added later