### PR TITLE
Fix pylint dependency from 2.6.1 -> 2.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Keep this in sync with setup.py
 nose2>=0.9.2
 nose2[coverage_plugin]>=0.6.5
-pylint>=2.6.0
+pylint==2.6.0
 cryptography~=3.3.2
 pyopenssl>=20.0.0
 PyInstaller>=4.0


### PR DESCRIPTION
### What does this PR do?
Our build is failing because of a push in minor version of pylint to 2.6.1

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation