### PR TITLE
Rename conjurrc parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-api-python3#89](https://github.com/cyberark/conjur-api-python3/issues/89)
 
 ### Changed
+- The .conjurrc parameters have been renamed from `account` to `conjur_account` and from `appliance_url` to `conjur_url`.
+  Additionally, the plugins parameter has been removed. This is a breaking change for users who generate their own
+  .conjurrc file for use in the SDK and will need to update accordingly.
+  [cyberark/conjur-api-python3#206](https://github.com/cyberark/conjur-api-python3/issues/206)
 - CLI command UX has been improved according to UX guidelines
   [cyberark/conjur-api-python3#132](https://github.com/cyberark/conjur-api-python3/issues/132)
   See [design guidelines](https://ljfz3b.axshare.com/#id=x8ktq8&p=conjur_help__init&g=1)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,8 +170,8 @@ repo. Copy this executable into every OS you wish to run the CLI integration tes
 
 ###### Example
 ```
-./integrations_tests_runner \
-  --identifier test-with-process \
+./dist/integrations_tests_runner \
+  --identifier test_with_process \
   --url https://conjur-server \
   --account someaccount \
   --login somelogin \

--- a/conjur/api/api.py
+++ b/conjur/api/api.py
@@ -45,7 +45,6 @@ class Api():
                  ca_bundle=None,
                  http_debug=False,
                  login_id=None,
-                 plugins=None,
                  ssl_verify=True,
                  url=None):
 

--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -94,8 +94,8 @@ class Client():
                                         "again with ssl_verify = False. Otherwise, reinitialize the client.")
 
                 logging.debug("Fetched connection details: "
-                              f"{{'account': {loaded_config['account']}, "
-                              f"'appliance_url': {loaded_config['url']}, "
+                              f"{{'conjur_account': {loaded_config['account']}, "
+                              f"'conjur_url': {loaded_config['url']}, "
                               f"'cert_file': {loaded_config['ca_bundle']}}}")
             except CertificateVerificationException:
                 raise

--- a/conjur/cli.py
+++ b/conjur/cli.py
@@ -581,7 +581,7 @@ Copyright (c) 2021 CyberArk Software Ltd. All rights reserved.
         Initializes the client, creating the .conjurrc file
         """
         ssl_service = SSLClient()
-        conjurrc_data = ConjurrcData(appliance_url=url,
+        conjurrc_data = ConjurrcData(conjur_url=url,
                                      account=account,
                                      cert_file=cert)
 

--- a/conjur/config.py
+++ b/conjur/config.py
@@ -27,10 +27,9 @@ class Config():
     # We intentionally remap some fields to friendlier names
     # Conjurrc field / Config name / Mandatory
     FIELDS = [
-        ('account', 'account', True),
-        ('appliance_url', 'url', True),
+        ('conjur_account', 'account', True),
+        ('conjur_url', 'url', True),
         ('cert_file', 'ca_bundle', False),
-        ('plugins', 'plugins', False),
     ]
 
     _config = {}

--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -62,30 +62,30 @@ class InitController:
         Method to get the certificate from the Conjur endpoint detailed by the user
         """
         # pylint: disable=line-too-long
-        if self.conjurrc_data.appliance_url is None:
-            self.conjurrc_data.appliance_url = input("Enter the URL of your Conjur server (use HTTPS prefix): ").strip()
-            if self.conjurrc_data.appliance_url == '':
+        if self.conjurrc_data.conjur_url is None:
+            self.conjurrc_data.conjur_url = input("Enter the URL of your Conjur server (use HTTPS prefix): ").strip()
+            if self.conjurrc_data.conjur_url == '':
                 # pylint: disable=raise-missing-from
                 raise RuntimeError("Error: URL is required")
 
         # Chops off the '/ if supplied by the user to avoid a server error
-        if self.conjurrc_data.appliance_url.endswith('/'):
-            self.conjurrc_data.appliance_url=self.conjurrc_data.appliance_url[:-1]
+        if self.conjurrc_data.conjur_url.endswith('/'):
+            self.conjurrc_data.conjur_url=self.conjurrc_data.conjur_url[:-1]
 
-        url = urlparse(self.conjurrc_data.appliance_url)
+        url = urlparse(self.conjurrc_data.conjur_url)
 
         # TODO: Factor out the following URL validation to ConjurrcData class
         # and add integration tests
         if url.scheme != 'https':
             raise RuntimeError(f"Error: undefined behavior. Reason: The Conjur URL format provided "
-                   f"'{self.conjurrc_data.appliance_url}' is not supported.")
+                   f"'{self.conjurrc_data.conjur_url}' is not supported.")
 
         if self.conjurrc_data.cert_file is not None:
             # Return None because we do not need to fetch the certificate
             return None
 
         # pylint: disable=logging-fstring-interpolation
-        logging.debug(f"Initiating a TLS connection with '{self.conjurrc_data.appliance_url}'")
+        logging.debug(f"Initiating a TLS connection with '{self.conjurrc_data.conjur_url}'")
         fingerprint, fetched_certificate = self.init_logic.get_certificate(url.hostname, url.port)
 
         sys.stdout.write(f"\nThe Conjur server's certificate SHA-1 fingerprint is:\n{fingerprint}\n")
@@ -103,7 +103,7 @@ class InitController:
         """
         Method to fetch the account from the user
         """
-        if conjurrc_data.account is None:
+        if conjurrc_data.conjur_account is None:
             try:
                 self.init_logic.fetch_account_from_server(self.conjurrc_data)
             except CertificateHostnameMismatchException:
@@ -114,8 +114,8 @@ class InitController:
                 # If the endpoint does not exist, the user will be prompted to enter in their account.
                 # pylint: disable=no-member
                 if hasattr(error.response, 'status_code') and str(error.response.status_code) == '401':
-                    conjurrc_data.account = input("Enter the Conjur account name (required): ").strip()
-                    if conjurrc_data.account is None or conjurrc_data.account == '':
+                    conjurrc_data.conjur_account = input("Enter the Conjur account name (required): ").strip()
+                    if conjurrc_data.conjur_account is None or conjurrc_data.conjur_account == '':
                         raise RuntimeError("Error: account is required")
                 else:
                     raise
@@ -124,7 +124,7 @@ class InitController:
         """
         Method to write the certificate fetched from the Conjur endpoint on the user's machine
         """
-        url = urlparse(self.conjurrc_data.appliance_url)
+        url = urlparse(self.conjurrc_data.conjur_url)
         # pylint: disable=line-too-long
         if self.conjurrc_data.cert_file is None and url.scheme == "https":
             self.conjurrc_data.cert_file = DEFAULT_CERTIFICATE_FILE

--- a/conjur/controller/login_controller.py
+++ b/conjur/controller/login_controller.py
@@ -84,7 +84,7 @@ class LoginController:
         properties and to send a login request to Conjur
         """
         conjurrc = ConjurrcData.load_from_file()
-        self.credential_data.machine = conjurrc.appliance_url + CREDENTIAL_HOST_PATH
+        self.credential_data.machine = conjurrc.conjur_url + CREDENTIAL_HOST_PATH
 
         return conjurrc
 

--- a/conjur/controller/logout_controller.py
+++ b/conjur/controller/logout_controller.py
@@ -37,7 +37,7 @@ class LogoutController:
                 sys.stdout.write("Successfully logged out from Conjur.\n")
             elif os.path.exists(DEFAULT_NETRC_FILE) and os.path.getsize(DEFAULT_NETRC_FILE) != 0:
                 conjurrc = ConjurrcData.load_from_file(DEFAULT_CONFIG_FILE)
-                self.logout_logic.remove_credentials(conjurrc.appliance_url)
+                self.logout_logic.remove_credentials(conjurrc.conjur_url)
                 logging.debug("Logout successful")
                 sys.stdout.write("Successfully logged out from Conjur.\n")
             else:

--- a/conjur/data_object/conjurrc_data.py
+++ b/conjur/data_object/conjurrc_data.py
@@ -19,11 +19,10 @@ class ConjurrcData:
     """
     Used for setting user input data
     """
-    def __init__(self, appliance_url=None, account=None, cert_file=None):
-        self.appliance_url = appliance_url
-        self.account = account
+    def __init__(self, conjur_url=None, account=None, cert_file=None):
+        self.conjur_url = conjur_url
+        self.conjur_account = account
         self.cert_file = cert_file
-        self.plugins = []
 
     @classmethod
     def load_from_file(cls, conjurrc_path=DEFAULT_CONFIG_FILE):
@@ -32,11 +31,11 @@ class ConjurrcData:
         """
         with open(conjurrc_path, 'r') as conjurrc:
             loaded_conjurrc = yaml_load(conjurrc, Loader=YamlLoader)
-            return ConjurrcData(loaded_conjurrc['appliance_url'],
-                                loaded_conjurrc['account'],
+            return ConjurrcData(loaded_conjurrc['conjur_url'],
+                                loaded_conjurrc['conjur_account'],
                                 loaded_conjurrc['cert_file'])
 
     # pylint: disable=line-too-long
     def __repr__(self):
-        return f"{{'appliance_url': '{self.appliance_url}', 'account': '{self.account}', " \
-               f"'cert_file': '{self.cert_file}', 'plugins': {self.plugins}}}"
+        return f"{{'conjur_url': '{self.conjur_url}', 'conjur_account': '{self.conjur_account}', " \
+               f"'cert_file': '{self.cert_file}'}}"

--- a/conjur/logic/init_logic.py
+++ b/conjur/logic/init_logic.py
@@ -53,11 +53,11 @@ class InitLogic:
         This endpoint only exists in the DAP server
         """
         params = {
-            'url': conjurrc_data.appliance_url
+            'url': conjurrc_data.conjur_url
         }
         # If the user provides us with the certificate path, we will use it
         # to make a request to /info
-        if conjurrc_data.cert_file is None and conjurrc_data.appliance_url.startswith("https"):
+        if conjurrc_data.cert_file is None and conjurrc_data.conjur_url.startswith("https"):
             certificate_path = os.path.join(os.path.dirname(DEFAULT_CONFIG_FILE),
                                           "conjur-server.pem")
         else:
@@ -68,10 +68,10 @@ class InitLogic:
                                    ConjurEndpoint.INFO,
                                    params,
                                    ssl_verify=certificate_path).json()
-        conjurrc_data.account = response['configuration']['conjur']['account']
+        conjurrc_data.conjur_account = response['configuration']['conjur']['account']
 
         # pylint: disable=logging-fstring-interpolation
-        logging.debug(f"Account '{conjurrc_data.account}' "
+        logging.debug(f"Account '{conjurrc_data.conjur_account}' "
                       "successfully fetched from the Conjur server")
 
     @classmethod

--- a/conjur/logic/login_logic.py
+++ b/conjur/logic/login_logic.py
@@ -34,8 +34,8 @@ class LoginLogic:
         Method to fetch the user/host's API key from Conjur
         """
         params = {
-            'url': conjurrc.appliance_url,
-            'account': conjurrc.account
+            'url': conjurrc.conjur_url,
+            'account': conjurrc.conjur_account
         }
 
         if ssl_verify is False:

--- a/conjur/logic/logout_logic.py
+++ b/conjur/logic/logout_logic.py
@@ -17,8 +17,8 @@ class LogoutLogic:
     def __init__(self, credentials):
         self.credentials = credentials
 
-    def remove_credentials(self, conjurrc_appliance_url):
+    def remove_credentials(self, conjurrc_conjur_url):
         """
         Method to remove credentials during logout
         """
-        self.credentials.remove_credentials(conjurrc_appliance_url)
+        self.credentials.remove_credentials(conjurrc_conjur_url)

--- a/conjur/logic/user_logic.py
+++ b/conjur/logic/user_logic.py
@@ -67,7 +67,7 @@ class UserLogic:
         keys and change passwords
         """
         loaded_conjurrc = self.conjurrc_data.load_from_file()
-        return self.credentials_from_store.load(loaded_conjurrc.appliance_url)
+        return self.credentials_from_store.load(loaded_conjurrc.conjur_url)
 
     def rotate_other_api_key(self, resource_to_update):
         """

--- a/conjur/util/credentials_from_file.py
+++ b/conjur/util/credentials_from_file.py
@@ -46,7 +46,7 @@ class CredentialsFromFile:
         # Ensures that the netrc file is only available its owner
         os.chmod(self.netrc_path, stat.S_IRWXU)
 
-    def load(self, conjurrc_appliance_url):
+    def load(self, conjurrc_conjur_url):
         """
         Method that loads the netrc data.
         Triggered before each CLI action
@@ -63,7 +63,7 @@ class CredentialsFromFile:
 
         logging.debug(f"Retrieving credentials from file: {self.netrc_path}")
         for host in netrc_obj.hosts:
-            if conjurrc_appliance_url in host:
+            if conjurrc_conjur_url in host:
                 netrc_host_url = host
                 netrc_auth = netrc_obj.authenticators(netrc_host_url)
 
@@ -89,11 +89,11 @@ class CredentialsFromFile:
         hosts[credential_data['machine']] = (user_to_update, None, new_api_key)
         self.build_netrc(netrc_obj)
 
-    def remove_credentials(self, conjurrc_appliance_url):
+    def remove_credentials(self, conjurrc_conjur_url):
         """
         Method that removes the described login entry from netrc
         """
-        netrc_data = self.load(conjurrc_appliance_url)
+        netrc_data = self.load(conjurrc_conjur_url)
 
         netrc_obj = netrc.netrc(DEFAULT_NETRC_FILE)
         hosts = netrc_obj.hosts

--- a/design/general_refactorings.md
+++ b/design/general_refactorings.md
@@ -257,7 +257,7 @@ The following is a mapping of builtin and third-party exceptions that are curren
     * `RuntimeError` should be replaced with `MissingParameterException`
 
       ```python
-      if self.conjurrc_data.appliance_url == '':
+      if self.conjurrc_data.conjur_url == '':
           raise RuntimeError("Error: URL is required")
       ```
 
@@ -266,7 +266,7 @@ The following is a mapping of builtin and third-party exceptions that are curren
   ```python
       if url.scheme != 'https':
           raise RuntimeError(f"Error: undefined behavior. Reason: The Conjur URL format provided "
-                 f"'{self.conjurrc_data.appliance_url}' is not supported.")
+                 f"'{self.conjurrc_data.conjur_url}' is not supported.")
   ```
 
 * `RuntimeError` should be replaced with `ConfirmationException`
@@ -286,9 +286,9 @@ The following is a mapping of builtin and third-party exceptions that are curren
           self.init_logic.fetch_account_from_server(self.conjurrc_data)
       except Exception as error:
           logging.warning(f"Unable to fetch the account from the Conjur server. Reason: {error}")
-          conjurrc_data.account = input("Enter the Conjur account name (required): ").strip()
+          conjurrc_data.conjur_account = input("Enter the Conjur account name (required): ").strip()
 
-          if conjurrc_data.account is None or conjurrc_data.account == '':
+          if conjurrc_data.conjur_account is None or conjurrc_data.conjur_account == '':
               raise RuntimeError("Error: account is required")
     ```
 
@@ -362,7 +362,7 @@ The following is a mapping of builtin and third-party exceptions that are curren
             sys.stdout.write("Successfully logged out from Conjur.\n")
         elif os.path.exists(DEFAULT_NETRC_FILE) and os.path.getsize(DEFAULT_NETRC_FILE) != 0:
             conjurrc = ConjurrcData.load_from_file(DEFAULT_CONFIG_FILE)
-            self.logout_logic.remove_credentials(conjurrc.appliance_url)
+            self.logout_logic.remove_credentials(conjurrc.conjur_url)
             logging.debug("Logout successful")
             sys.stdout.write("Successfully logged out from Conjur.\n")
         else:

--- a/test/test_config/bad_cert_conjurrc
+++ b/test/test_config/bad_cert_conjurrc
@@ -1,5 +1,4 @@
 ---
-account: dev
-appliance_url: https://conjur-https
+conjur_account: dev
+conjur_url: https://conjur-https
 cert_file: ./test/test_config/https/nginx.conf
-plugins: []

--- a/test/test_config/good_conjurrc
+++ b/test/test_config/good_conjurrc
@@ -1,5 +1,4 @@
 ---
-account: accountname
-appliance_url: https://someurl/somepath
+conjur_account: accountname
+conjur_url: https://someurl/somepath
 cert_file: "/cert/file/location"
-plugins: ['foo', 'bar']

--- a/test/test_config/missing_account_conjurrc
+++ b/test/test_config/missing_account_conjurrc
@@ -1,4 +1,3 @@
 ---
-appliance_url: https://someurl/somepath
+conjur_url: https://someurl/somepath
 cert_file: "/cert/file/location"
-plugins: ['foo', 'bar']

--- a/test/test_config/missing_url_conjurrc
+++ b/test/test_config/missing_url_conjurrc
@@ -1,4 +1,3 @@
 ---
-account: accountname
+conjur_account: accountname
 cert_file: "/cert/file/location"
-plugins: ['foo', 'bar']

--- a/test/test_config/no_cert_conjurrc
+++ b/test/test_config/no_cert_conjurrc
@@ -1,5 +1,4 @@
 ---
-account: dev
-appliance_url: https://conjur-https
+conjur_account: dev
+conjur_url: https://conjur-https
 cert_file: ''
-plugins: []

--- a/test/test_integration_configurations.py
+++ b/test/test_integration_configurations.py
@@ -133,7 +133,7 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
     @integration_test(True)
     def test_https_cli_fails_if_cert_is_bad(self):
         # bad conjurrc
-        conjurrc = ConfigFile(account=self.client_params.login, appliance_url=self.client_params.hostname,
+        conjurrc = ConfigFile(account=self.client_params.login, conjur_url=self.client_params.hostname,
                               cert_file=self.environment.path_provider.nginx_conf_path)
         conjurrc.dump_to_file()
         with open(f"{DEFAULT_NETRC_FILE}", "w") as netrc_test:
@@ -146,7 +146,7 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
 
     @integration_test(True)
     def test_https_cli_fails_if_cert_is_not_provided(self):
-        conjurrc = ConfigFile(account=self.client_params.login, appliance_url=self.client_params.hostname,
+        conjurrc = ConfigFile(account=self.client_params.login, conjur_url=self.client_params.hostname,
                               cert_file="")
         conjurrc.dump_to_file()
         with open(f"{DEFAULT_NETRC_FILE}", "w") as netrc_test:

--- a/test/test_integration_oss.py
+++ b/test/test_integration_oss.py
@@ -61,5 +61,5 @@ class CliIntegrationTestOSS(IntegrationTestCaseBase):
             with open(f"{DEFAULT_CONFIG_FILE}", 'r') as conjurrc:
                 lines = conjurrc.readlines()
                 assert "---" in lines[0]
-                assert "account: someotheraccount" in lines[1]
-                assert f"appliance_url: {self.client_params.hostname}" in lines[2]
+                assert "conjur_account: someotheraccount" in lines[2]
+                assert f"conjur_url: {self.client_params.hostname}" in lines[3]

--- a/test/test_unit_cli.py
+++ b/test/test_unit_cli.py
@@ -16,7 +16,7 @@ RESOURCE_LIST = [
     'some_id2',
 ]
 WHOAMI_RESPONSE = {
-    "account": "myaccount"
+    "conjur_account": "myaccount"
 }
 
 class MockArgs(object):
@@ -216,7 +216,7 @@ Copyright (c) 2021 CyberArk Software Ltd. All rights reserved.
 
     @cli_test(["whoami"], whoami_output=WHOAMI_RESPONSE)
     def test_cli_invokes_whoami_outputs_formatted_json(self, cli_invocation, output, client):
-        self.assertEquals('{\n    "account": "myaccount"\n}\n', output)
+        self.assertEquals('{\n    "conjur_account": "myaccount"\n}\n', output)
 
     @patch.object(Cli, 'handle_init_logic')
     def test_cli_init_functions_are_properly_called(self, mock_init):

--- a/test/test_unit_config.py
+++ b/test/test_unit_config.py
@@ -15,7 +15,6 @@ class ConfigTest(unittest.TestCase):
     EXPECTED_CONFIG = {
       'account': 'accountname',
       'ca_bundle': '/cert/file/location',
-      'plugins': ['foo', 'bar'],
       'url': 'https://someurl/somepath',
     }
 
@@ -47,7 +46,6 @@ class ConfigTest(unittest.TestCase):
                 "^config:\n" +
                 "\s+account: accountname\n" +
                 "\s+ca_bundle: /cert/file/location\n" +
-                "\s+plugins:.*foo.*bar.*\n" +
                 "\s+url: https://someurl/somepath\n",
                 re.MULTILINE | re.DOTALL,
             ))

--- a/test/test_unit_conjurrc_data.py
+++ b/test/test_unit_conjurrc_data.py
@@ -3,17 +3,16 @@ from unittest.mock import mock_open, patch
 
 from conjur.data_object.conjurrc_data import ConjurrcData
 
-EXPECTED_REP_OBJECT={'appliance_url': 'https://someurl', 'account': 'someaccount', 'cert_file': "/some/cert/path", 'plugins': []}
+EXPECTED_REP_OBJECT={'conjur_url': 'https://someurl', 'conjur_account': 'someaccount', 'cert_file': "/some/cert/path"}
 EXPECTED_CONJURRC = \
 """
 ---
-account: someacc
-appliance_url: https://someurl
+conjur_account: someacc
+conjur_url: https://someurl
 cert_file: /some/path/to/pem
-plugins: []
 """
 
-CONJURRC_DICT = {'appliance_url': 'https://someurl', 'account': 'someacc', 'cert_file': '/some/path/to/pem', 'plugins':[]}
+CONJURRC_DICT = {'conjur_url': 'https://someurl', 'conjur_account': 'someacc', 'cert_file': '/some/path/to/pem'}
 
 class ConjurrcDataTest(unittest.TestCase):
 

--- a/test/test_unit_init_controller.py
+++ b/test/test_unit_init_controller.py
@@ -42,7 +42,7 @@ class InitControllerTest(unittest.TestCase):
         mock_init_logic.fetch_account_from_server = MagicMock(side_effect=requests.exceptions.SSLError(response=mock_response))
         mock_conjurrc_data = ConjurrcData()
         with self.assertRaises(RuntimeError):
-            mock_conjurrc_data.appliance_url = 'https://someurl'
+            mock_conjurrc_data.conjur_url = 'https://someurl'
             mock_init_controller = InitController(mock_conjurrc_data, mock_init_logic, False, True)
             mock_init_controller.get_account_info(mock_conjurrc_data)
 
@@ -53,17 +53,17 @@ class InitControllerTest(unittest.TestCase):
         mock_response.status_code = 401
         mock_init_logic.fetch_account_from_server = MagicMock(side_effect=requests.exceptions.SSLError(response=mock_response))
         mock_conjurrc_data = ConjurrcData()
-        mock_conjurrc_data.appliance_url="https://someaccount"
+        mock_conjurrc_data.conjur_url="https://someaccount"
         mock_init_controller = InitController(mock_conjurrc_data, mock_init_logic, False, True)
         mock_init_controller.get_account_info(mock_conjurrc_data)
-        self.assertEquals(mock_conjurrc_data.account, 'someaccount')
+        self.assertEquals(mock_conjurrc_data.conjur_account, 'someaccount')
 
     '''
     When user does not trust the certificate, an exception will be raised
     '''
     @patch('builtins.input', side_effect=['no'])
     def test_init_not_trusting_cert_raises_error(self, mock_input):
-        self.conjurrc_data.appliance_url = 'https://someurl'
+        self.conjurrc_data.conjur_url = 'https://someurl'
         ctx = SSL.Context(method=SSL.TLSv1_2_METHOD)
         sock = OpenSSL.SSL.Connection(ctx)
         self.init_logic.connect = MagicMock(return_value = sock)
@@ -79,7 +79,7 @@ class InitControllerTest(unittest.TestCase):
     @patch('builtins.input', side_effect=['yes'])
     def test_init_user_trusts_cert_returns_cert(self, mock_input):
         mock_certificate = "cert"
-        self.conjurrc_data.appliance_url = "https://someurl"
+        self.conjurrc_data.conjur_url = "https://someurl"
         self.init_logic.get_certificate = MagicMock(return_value = ["12:AB", mock_certificate])
         init_controller = InitController(self.conjurrc_data,self.init_logic, self.force_overwrite, self.ssl_verify)
         fetched_certificate = init_controller.get_server_certificate()
@@ -109,7 +109,7 @@ class InitControllerTest(unittest.TestCase):
     @patch('builtins.input', return_value='yes')
     def test_user_confirms_force_overwrites_writes_cert_to_file(self, mock_input, mock_init_logic):
         with redirect_stdout(self.capture_stream):
-            self.conjurrc_data.appliance_url = "https://someurl"
+            self.conjurrc_data.conjur_url = "https://someurl"
             init_controller = InitController(self.conjurrc_data, mock_init_logic, False, True)
             # Mock that a certificate file already exists
             mock_init_logic.write_certificate_to_file.return_value = False
@@ -130,7 +130,7 @@ class InitControllerTest(unittest.TestCase):
     @patch('builtins.input', return_value='yes')
     def test_user_confirms_force_overwrites_writes_conjurrc_to_file(self, mock_input, mock_init_logic):
         with redirect_stdout(self.capture_stream):
-            self.conjurrc_data.appliance_url = "https://someurl"
+            self.conjurrc_data.conjur_url = "https://someurl"
             init_controller = InitController(self.conjurrc_data, mock_init_logic, False, True)
             # Mock that a conjurrc file already exists
             mock_init_logic.write_conjurrc.return_value = False
@@ -141,7 +141,7 @@ class InitControllerTest(unittest.TestCase):
 
     @patch('builtins.input', return_value='')
     def test_user_does_not_input_url_raises_error(self, mock_input):
-        mock_conjurrc_data = ConjurrcData(appliance_url=None)
+        mock_conjurrc_data = ConjurrcData(conjur_url=None)
         with self.assertRaises(RuntimeError) as context:
             init_controller = InitController(mock_conjurrc_data, self.init_logic, self.force_overwrite, self.ssl_verify)
             init_controller.get_server_certificate()
@@ -149,7 +149,7 @@ class InitControllerTest(unittest.TestCase):
 
     @patch('builtins.input', return_value='somehost')
     def test_user_does_not_input_https_will_raises_error(self, mock_input):
-        mock_conjurrc_data = ConjurrcData(appliance_url='somehost')
+        mock_conjurrc_data = ConjurrcData(conjur_url='somehost')
         with self.assertRaises(RuntimeError) as context:
             init_controller = InitController(mock_conjurrc_data, self.init_logic, self.force_overwrite, self.ssl_verify)
             init_controller.get_server_certificate()

--- a/test/test_unit_init_logic.py
+++ b/test/test_unit_init_logic.py
@@ -16,10 +16,9 @@ MIIDOD...
 
 EXPECTED_CONFIG= \
 '''---
-account: someaccount
-appliance_url: https://someurl
+conjur_account: someaccount
+conjur_url: https://someurl
 cert_file: /path/to/conjur-someaccount.pem
-plugins: [foo, bar]
 '''
 
 class InitLogicTest(unittest.TestCase):
@@ -78,9 +77,8 @@ class InitLogicTest(unittest.TestCase):
                 with open('path/to/conjurrc', 'r') as conjurrc:
                     lines = conjurrc.readlines()
                     self.assertEquals(lines[0].strip(), "---")
-                    self.assertEquals(lines[1].strip(), "account: someaccount")
+                    self.assertEquals(lines[1].strip(), "conjur_account: someaccount")
                     self.assertEquals(lines[3].strip(), "cert_file: /path/to/conjur-someaccount.pem")
-                    self.assertEquals(lines[4].strip(), "plugins: [foo, bar]")
 
     def test_cert_error_will_raise_exception(self):
         with patch.object(SSLClient, 'get_certificate', side_effect=Exception) as mock_get_cert:

--- a/test/test_unit_login_controller.py
+++ b/test/test_unit_login_controller.py
@@ -9,10 +9,9 @@ from conjur.logic.login_logic import LoginLogic
 
 
 class MockConjurrc:
-    appliance_url = 'https://someurl'
+    conjur_url = 'https://someurl'
     account = 'someacc'
     cert_file = 'some/path/to/pem'
-    plugins: []
 
 
 class MockCredentialsData:

--- a/test/test_unit_login_logic.py
+++ b/test/test_unit_login_logic.py
@@ -13,16 +13,14 @@ class MockCredentialsData:
     api_key = 'somepass'
 
 class MockConjurrc:
-    appliance_url = 'https://someurl'
-    account = 'someacc'
+    conjur_url = 'https://someurl'
+    conjur_account = 'someacc'
     cert_file = 'some/path/to/pem'
-    plugins: []
 
 class MockConjurrcEmptyCertEntry:
-    appliance_url = 'https://someurl'
-    account = 'someacc'
+    conjur_url = 'https://someurl'
+    conjur_account = 'someacc'
     cert_file = ''
-    plugins: []
 
 class MockClientResponse():
     def __init__(self, text='myretval', content='mycontent'):

--- a/test/test_unit_logout_controller.py
+++ b/test/test_unit_logout_controller.py
@@ -1,16 +1,14 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from conjur.data_object.conjurrc_data import ConjurrcData
 from conjur.controller.logout_controller import LogoutController
 from conjur.logic.logout_logic import LogoutLogic
 
 
 class MockConjurrc:
-    appliance_url = 'https://someurl'
-    account = 'someacc'
+    conjur_url = 'https://someurl'
+    conjur_account = 'someacc'
     cert_file = 'some/path/to/pem'
-    plugins: []
 
 
 class LogoutControllerTest(unittest.TestCase):
@@ -29,7 +27,7 @@ class LogoutControllerTest(unittest.TestCase):
         mock_logout_logic.remove_credentials = MagicMock()
         mock_logout_controller = LogoutController(True, mock_logout_logic)
         mock_logout_controller.remove_credentials()
-        mock_logout_logic.remove_credentials.assert_called_once_with(MockConjurrc.appliance_url)
+        mock_logout_logic.remove_credentials.assert_called_once_with(MockConjurrc.conjur_url)
 
     @patch('os.path.exists', return_value=True)
     @patch('os.path.getsize', return_value=0)

--- a/test/test_unit_user_logic.py
+++ b/test/test_unit_user_logic.py
@@ -10,16 +10,14 @@ from conjur.logic.user_logic import UserLogic
 
 
 class MockConjurrc:
-    appliance_url = 'someurl'
+    conjur_url = 'someurl'
     account = 'someacc'
     cert_file = 'some/path/to/pem'
-    plugins: []
 
 
-CONJURRC_DICT = {'appliance_url': 'someurl',
+CONJURRC_DICT = {'conjur_url': 'someurl',
                  'account': 'someacc',
-                 'cert_file': 'some/path/to/pem',
-                 'plugins': []}
+                 'cert_file': 'some/path/to/pem'}
 
 
 class UserLogicTest(unittest.TestCase):

--- a/test/util/models/configfile.py
+++ b/test/util/models/configfile.py
@@ -3,18 +3,16 @@ from conjur.constants import *
 
 
 class ConfigFile:
-    def __init__(self, account=None, appliance_url=None, cert_file=None, plugins=[]):
+    def __init__(self, account=None, conjur_url=None, cert_file=None):
         self.account = account
-        self.appliance_url = appliance_url
+        self.conjur_url = conjur_url
         self.cert_file = cert_file
-        self.plugins = plugins
 
     def __str__(self):
         str = "---\n"
-        str += f"account: {self.account}\n"
-        str += f"appliance_url: {self.appliance_url}\n"
+        str += f"conjur_account: {self.account}\n"
+        str += f"conjur_url: {self.conjur_url}\n"
         str += f"cert_file: {self.cert_file}\n"
-        str += f"plugins: {self.plugins}"
         return str
 
     def dump_to_file(self, file_path=DEFAULT_CONFIG_FILE):
@@ -27,11 +25,9 @@ class ConfigFile:
         ret = ConfigFile()
         with open(file_path, 'r') as f:
             for line in f.readlines():
-                if line.strip().startswith('account'):
+                if line.strip().startswith('conjur_account'):
                     ret.account = "".join(line.split(":")[1:]).strip()
-                if line.strip().startswith('appliance_url'):
-                    ret.appliance_url = "".join(line.split(":")[1:]).strip()
+                if line.strip().startswith('conjur_url'):
+                    ret.conjur_url = "".join(line.split(":")[1:]).strip()
                 if line.strip().startswith('cert_file'):
                     ret.cert_file = "".join(line.split(":")[1:]).strip()
-                if line.strip().startswith('plugins'):
-                    ret.plugins = "".join(line.split(":")[1:]).strip()

--- a/test/util/test_helpers.py
+++ b/test/util/test_helpers.py
@@ -45,10 +45,9 @@ def verify_conjurrc_contents(account, hostname, cert):
     with open(f"{DEFAULT_CONFIG_FILE}", 'r') as conjurrc:
         lines = conjurrc.readlines()
         assert "---" in lines[0]
-        assert f"account: {account}" in lines[1]
-        assert f"appliance_url: {hostname}" in lines[2]
-        assert f"cert_file: {cert}" in lines[3]
-        assert f"plugins: []" in lines[4]
+        assert f"cert_file: {cert}" in lines[1]
+        assert f"conjur_account: {account}" in lines[2]
+        assert f"conjur_url: {hostname}" in lines[3]
 
  # *************** VARIABLE ***************
 


### PR DESCRIPTION
The following conjurrc parameters were renamed account -> conjur_account and appliance_url -> conjur_url. Additionally, the `plugins` paramters was removed as this is leftover from v4

### What ticket does this PR close?
Resolves #206 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation