### PR TITLE
Remove publishing to PyPI (see description for more info)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,19 +49,19 @@ pipeline {
         }
       }
     }
-
+    // Temporarily comment this out until either the SDK is GA or the two use-cases are separated
     // Only publish if the HEAD is tagged with the same version as in __version__.py
     stage('Publish') {
       parallel {
-        stage('Publish to PyPI') {
-          steps {
-            sh 'summon -e production ./bin/publish_package'
-          }
+        //stage('Publish to PyPI') {
+        //  steps {
+        //    sh 'summon -e production ./bin/publish_package'
+        //  }
 
-          when {
-            branch "master"
-          }
-        }
+        //  when {
+        //    branch "master"
+        //  }
+        //}
 
         stage('Publish containers') {
           steps {


### PR DESCRIPTION
### What does this PR do?
We push the CLI and SDK as a single package to PyPi so that users with Python installed can easily pull the CLI for human-use and SDK for application-use. The code for the SDK and CLI are together under a single repo and pushed to PyPi as a single library. Because only the CLI is to be promoted to GA (v7.0.0) we cannot continue to push both the CLI and the SDK together to PyPI and there is no way (at the moment) to separate the artifacts into two different libraries so that the client can remain < v1.0.0.
An [issue](https://github.com/cyberark/conjur-api-python3/issues/211) was open to properly address this.

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
Will be a separate PR