### PR TITLE
Add support for short-hand 'y' (yes) for confirmation

### DIFF
--- a/conjur/constants.py
+++ b/conjur/constants.py
@@ -26,7 +26,7 @@ DEFAULT_NETRC_FILE = os.path.expanduser(os.path.join('~', DEFAULT_NETRC_FILE_NAM
 DEFAULT_CERTIFICATE_FILE = os.path.expanduser(os.path.join('~', "conjur-server.pem"))
 CREDENTIAL_HOST_PATH = "/authn"
 
-
+VALID_CONFIRMATIONS = ["yes", "y"]
 
 # For testing purposes
 TEST_HOSTNAME = "https://conjur-https"

--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -15,7 +15,7 @@ import sys
 from urllib.parse import urlparse
 
 # Internals
-from conjur.constants import DEFAULT_CERTIFICATE_FILE, DEFAULT_CONFIG_FILE
+from conjur.constants import DEFAULT_CERTIFICATE_FILE, DEFAULT_CONFIG_FILE, VALID_CONFIRMATIONS
 from conjur.errors import CertificateHostnameMismatchException
 from conjur.util import util_functions
 
@@ -93,7 +93,7 @@ class InitController:
                          "command on the Conjur server:\n"
                          "openssl x509 -fingerprint -noout -in ~conjur/etc/ssl/conjur.pem\n\n")
         trust_certificate = input("Trust this certificate? (Default=no): ").strip()
-        if trust_certificate.lower() != 'yes':
+        if trust_certificate.lower() not in VALID_CONFIRMATIONS:
             raise RuntimeError("You decided not to trust the certificate")
 
         return fetched_certificate
@@ -160,5 +160,5 @@ class InitController:
         """
         force_overwrite = input(f"File {config_file} exists. "
                                 f"Overwrite? (Default=yes): ").strip()
-        if force_overwrite != '' and force_overwrite.lower() != 'yes':
+        if force_overwrite != '' and force_overwrite.lower() not in VALID_CONFIRMATIONS:
             raise Exception(f"Not overwriting {config_file}")

--- a/test/test_integration_configurations.py
+++ b/test/test_integration_configurations.py
@@ -86,6 +86,36 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
         assert os.path.isfile(DEFAULT_CERTIFICATE_FILE)
 
     '''
+    Validates that the conjurrc was created on the machine when user provides Y instead of 'yes'
+    '''
+    @integration_test(True)
+    @patch('builtins.input', return_value='Y')
+    def test_https_conjurrc_is_created_when_user_provides_y_instead_of_yes(self, mock_input):
+        self.setup_cli_params({})
+        self.invoke_cli(self.cli_auth_params,
+                        ['init', '--url', self.client_params.hostname, '--account', 'someaccount'])
+
+        utils.verify_conjurrc_contents('someaccount', self.client_params.hostname, self.environment.path_provider.certificate_path)
+        assert os.path.isfile(DEFAULT_CERTIFICATE_FILE)
+
+    '''
+    Validates that the conjurrc was created on the machine when user provides Y instead of 'yes' 
+    when prompted to overwrite the conjurrc file
+    '''
+    @integration_test(True)
+    @patch('builtins.input', side_effect=['Y', 'Y', 'Y', 'Y'])
+    def test_https_conjurrc_is_created_when_user_provides_y_instead_of_yes_for_overwrite(self, mock_input):
+        self.setup_cli_params({})
+        self.invoke_cli(self.cli_auth_params,
+                        ['init', '--url', self.client_params.hostname, '--account', 'someaccount'])
+        # Intentional double init here to test that the overwriting of the file prompt can take 'Y'
+        self.invoke_cli(self.cli_auth_params,
+                        ['init', '--url', self.client_params.hostname, '--account', 'someaccount'])
+
+        utils.verify_conjurrc_contents('someaccount', self.client_params.hostname, self.environment.path_provider.certificate_path)
+        assert os.path.isfile(DEFAULT_CERTIFICATE_FILE)
+
+    '''
     Validates that the conjurrc was created on the machine when a user mistakenly supplies an extra '/' at the end of the URL
     '''
     @integration_test()


### PR DESCRIPTION
### What does this PR do?
We previously only supported 'yes' and 'YES' for confirmation. Now, 'y' and 'Y' are supported.

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation