### PR TITLE
Update change-password tests to change non-admin passwords and fix failing UTs

### DIFF
--- a/test/test_integration_resource.py
+++ b/test/test_integration_resource.py
@@ -108,7 +108,7 @@ class CliIntegrationResourceTest(IntegrationTestCaseBase):  # pragma: no cover
                                                ['user', 'rotate-api-key', '-i', 'someunprivilegeduser'])
         # extract the API key we get from the CLI success message
         extract_api_key_from_message = unprivileged_api_key.split(":")[1].strip()
-        print(extract_api_key_from_message)
+
         # verify user can login with their new API key
         self.invoke_cli(self.cli_auth_params,
                         ['login', '-i', 'someunprivilegeduser', '-p', extract_api_key_from_message])
@@ -158,6 +158,14 @@ class CliIntegrationResourceTest(IntegrationTestCaseBase):  # pragma: no cover
 
     @integration_test(True)
     def test_user_change_password_not_complex_enough_prompts_input(self):
+        # Login as user to avoid changing admin password
+        some_user_api_key = self.invoke_cli(self.cli_auth_params,
+                                            ['user', 'rotate-api-key', '-i', 'someuser'])
+        extract_api_key_from_message = some_user_api_key.split(":")[1].strip()
+
+        self.invoke_cli(self.cli_auth_params,
+                        ['login', '-i', 'someuser', '-p', extract_api_key_from_message])
+
         output = self.invoke_cli(self.cli_auth_params,
                                  ['user', 'change-password', '-p', 'someinvalidpassword'], exit_code=1)
         self.assertIn("Error: Invalid password", output)
@@ -177,6 +185,13 @@ class CliIntegrationResourceTest(IntegrationTestCaseBase):  # pragma: no cover
 
     @integration_test()
     def test_user_change_password_empty_password_provided_prompts_input(self):
+        # Login as user to avoid changing admin password
+        some_user_api_key = self.invoke_cli(self.cli_auth_params,
+                                            ['user', 'rotate-api-key', '-i', 'someuser'])
+        extract_api_key_from_message = some_user_api_key.split(":")[1].strip()
+
+        self.invoke_cli(self.cli_auth_params,
+                        ['login', '-i', 'someuser', '-p', extract_api_key_from_message])
         with self.assertLogs('', level='DEBUG') as mock_log:
             with patch('getpass.getpass', side_effect=['mypassword']):
                 output = self.invoke_cli(self.cli_auth_params,

--- a/test/test_unit_logout_logic.py
+++ b/test/test_unit_logout_logic.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from conjur.util.credentials_from_file import CredentialsFromFile
 from conjur.logic.logout_logic import LogoutLogic
@@ -12,10 +12,8 @@ class LogoutLogicTest(unittest.TestCase):
 
         self.assertEquals(mock_logout_logic.credentials, mock_credentials)
 
-    def test_logout_remove_credentials_calls_remove_credentials(self):
-        mock_credentials = CredentialsFromFile
+    @patch('conjur.util.credentials_from_file')
+    def test_logout_remove_credentials_calls_remove_credentials(self, mock_credentials):
         mock_logout_logic = LogoutLogic(mock_credentials)
-        mock_credentials.remove_credentials = MagicMock()
-
         mock_logout_logic.remove_credentials("someurl")
         mock_credentials.remove_credentials.assert_called_once_with("someurl")

--- a/test/test_unit_user_controller.py
+++ b/test/test_unit_user_controller.py
@@ -20,8 +20,8 @@ class UserControllerTest(unittest.TestCase):
         assert user_controller.user_logic == mock_user_logic
         assert user_controller.user_input_data == mock_user_input_data
 
-    def test_operation_failure_raises_error(self):
-        mock_user_logic = UserLogic
+    @patch('conjur.logic.user_logic')
+    def test_operation_failure_raises_error(self, mock_user_logic):
         user_controller = UserController(mock_user_logic, self.user_input_data)
         mock_user_logic.rotate_api_key = MagicMock(side_effect=OperationNotCompletedException)
         with self.assertRaises(OperationNotCompletedException):
@@ -34,11 +34,11 @@ class UserControllerTest(unittest.TestCase):
         with self.assertRaises(OperationNotCompletedException):
             mock_user_controller.rotate_api_key()
 
-    def test_change_password_can_raise_authn_error(self):
+    @patch('conjur.logic.user_logic')
+    def test_change_password_can_raise_authn_error(self, mock_user_logic):
         # mock the status code of the error received
         mock_response = MagicMock()
         mock_response.status_code = 401
-        mock_user_logic = UserLogic
         user_controller = UserController(mock_user_logic, self.user_input_data)
         user_controller.prompt_for_password = MagicMock()
         mock_user_logic.change_personal_password = MagicMock(
@@ -46,11 +46,11 @@ class UserControllerTest(unittest.TestCase):
         with self.assertRaises(requests.exceptions.HTTPError):
             user_controller.change_personal_password()
 
-    def test_change_password_can_raise_invalid_complexity_error(self):
+    @patch('conjur.logic.user_logic')
+    def test_change_password_can_raise_invalid_complexity_error(self, mock_user_logic):
         # mock the status code of the error received
         mock_response = MagicMock()
         mock_response.status_code = 422
-        mock_user_logic = UserLogic
         user_controller = UserController(mock_user_logic, self.user_input_data)
         user_controller.prompt_for_password = MagicMock()
         mock_user_logic.change_personal_password = MagicMock(

--- a/test/test_unit_user_logic.py
+++ b/test/test_unit_user_logic.py
@@ -97,10 +97,10 @@ class UserLogicTest(unittest.TestCase):
     Raises exception when HTTPError was raised
     '''
     def test_rotate_personal_api_key_raises_exception_when_unauthorized(self):
-        client = MagicMock(return_value=None)
-        mock_user_logic = UserLogic(ConjurrcData, CredentialsFromFile, client)
-        mock_user_logic.client.rotate_personal_api_key = MagicMock(side_effect=requests.exceptions.HTTPError)
         with self.assertRaises(requests.exceptions.HTTPError):
+            client = MagicMock(return_value=None)
+            mock_user_logic = UserLogic(ConjurrcData, CredentialsFromFile, client)
+            mock_user_logic.client.rotate_personal_api_key = MagicMock(side_effect=requests.exceptions.HTTPError)
             mock_user_logic.rotate_personal_api_key('someuser', 'somecreds', 'somepass')
 
     '''


### PR DESCRIPTION
### What does this PR do?
Password complexity restriction was a feature introduced in a relatively newer version of Conjur. Before release we need to check against these older server versions and therefore when running the integration tests for change-password, the tests were failing because an error was not being raised and the actual password was being changed which leads to failing tests on future runs. This fixes this by attempting to change the password on a dummy user instead of admin's.

This PR also gives our broken UT build. The instability was coming the way at which the Jenkins pipeline is running the tests. 

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation