### PR TITLE
Suppress keyring logs

### DIFF
--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -18,6 +18,7 @@ from conjur.util import util_functions
 from conjur.api import Api
 from conjur.config import Config as ApiConfig
 from conjur.resource import Resource
+from conjur.wrapper import KeystoreAdapter
 
 
 # pylint: disable=pointless-string-statement
@@ -146,6 +147,9 @@ class Client():
         """
         Configures the logging for the client
         """
+        # Suppress third party logs
+        KeystoreAdapter.configure_keyring_log()
+
         if debug:
             logging.basicConfig(level=logging.DEBUG, format=self.LOGGING_FORMAT)
         else:

--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -148,7 +148,7 @@ class Client():
         Configures the logging for the client
         """
         # Suppress third party logs
-        KeystoreAdapter.configure_keyring_log()
+        KeystoreAdapter.configure_keyring_log_to_info()
 
         if debug:
             logging.basicConfig(level=logging.DEBUG, format=self.LOGGING_FORMAT)

--- a/conjur/wrapper/keystore_adapter.py
+++ b/conjur/wrapper/keystore_adapter.py
@@ -83,8 +83,8 @@ class KeystoreAdapter:
         return True
 
     @classmethod
-    def configure_keyring_log(cls):
+    def configure_keyring_log_to_info(cls):
         """
-        Method to configure the keyring logs
+        Method to configure the keyring logs to info
         """
-        logging.getLogger('keyring').setLevel(logging.WARNING)
+        logging.getLogger('keyring').setLevel(logging.INFO)

--- a/conjur/wrapper/keystore_adapter.py
+++ b/conjur/wrapper/keystore_adapter.py
@@ -77,8 +77,14 @@ class KeystoreAdapter:
             # not be configured correctly and not available for use. Therefore, false
             # will be returned
             keyring.get_password('test-system', 'test-accessibility')
-        except keyring.errors.KeyringError as keyring_error:
-            logging.debug(keyring_error)
+        except keyring.errors.KeyringError:
             return False
 
         return True
+
+    @classmethod
+    def configure_keyring_log(cls):
+        """
+        Method to configure the keyring logs
+        """
+        logging.getLogger('keyring').setLevel(logging.WARNING)


### PR DESCRIPTION
### What does this PR do?

This PR suppresses the third party keyring's logs. 

Previously, we would get a log in debug mode for all loaded keyrings 
```
conjur -d init -u https://sigallb.aim-dev.conjur.net
2021-04-01 08:56:30,043 DEBUG: Loading KWallet
2021-04-01 08:56:30,044 DEBUG: Loading SecretService
2021-04-01 08:56:30,046 DEBUG: Loading Windows
2021-04-01 08:56:30,047 DEBUG: Loading chainer
2021-04-01 08:56:30,048 DEBUG: Loading macOS
2021-04-01 08:56:30,068 DEBUG: Initiating a TLS connection with 'https://sigallb.aim-dev.conjur.net'...
...
```
This removes this and now we get:
```
conjur -d init -u https://sigallb.aim-dev.conjur.net
2021-04-01 08:56:30,068 DEBUG: Initiating a TLS connection with 'https://sigallb.aim-dev.conjur.net'...
```

### What ticket does this PR close?
Resolves #-

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation