### PR TITLE
Fix bug for prompting user for url in insecure mode

### DIFF
--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -60,7 +60,7 @@ class Client():
                  url=None):
 
         if ssl_verify is False:
-            util_functions.get_insecure_warning()
+            util_functions.get_insecure_warning_in_debug()
 
         self.setup_logging(debug)
 

--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -54,9 +54,10 @@ class InitController:
             # or CA-signed, we will write the certificate on the machine
             self.write_certificate(fetched_certificate)
         else:
-            logging.warning('You chose to initialize the client in insecure mode. Reinitialize '
-                            'the client should you choose to communicate to the server securely')
-            self.conjurrc_data.cert_file=""
+            logging.warning('You chose to initialize the client in insecure mode. If you '
+                            'If you prefer to communicate with the server securely, you '
+                            'must reinitialize the client in secure mode.')
+            self.conjurrc_data.cert_file = ""
 
         self.get_account_info(self.conjurrc_data)
         self.write_conjurrc()

--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -54,9 +54,6 @@ class InitController:
             # or CA-signed, we will write the certificate on the machine
             self.write_certificate(fetched_certificate)
         else:
-            logging.warning('You chose to initialize the client in insecure mode. If you '
-                            'If you prefer to communicate with the server securely, you '
-                            'must reinitialize the client in secure mode.')
             self.conjurrc_data.cert_file = ""
 
         self.get_account_info(self.conjurrc_data)

--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -43,7 +43,7 @@ class InitController:
         Method that facilitates all method calls in this class
         """
         if self.conjurrc_data.conjur_url is None:
-            self.get_conjur_url()
+            self.prompt_for_conjur_url()
 
         formatted_conjur_url = self.format_conjur_url()
         self.validate_conjur_url(formatted_conjur_url)
@@ -63,7 +63,7 @@ class InitController:
 
         sys.stdout.write("Successfully initialized the Conjur CLI\n")
 
-    def get_conjur_url(self):
+    def prompt_for_conjur_url(self):
         """
         Method to get the Conjur server URL if not provided
         """

--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -32,7 +32,8 @@ class InitController:
     def __init__(self, conjurrc_data, init_logic, force, ssl_verify):
         self.ssl_verify = ssl_verify
         if self.ssl_verify is False:
-            util_functions.get_insecure_warning()
+            util_functions.get_insecure_warning_in_debug()
+            util_functions.get_insecure_warning_in_warning()
 
         self.conjurrc_data = conjurrc_data
         self.init_logic = init_logic

--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -88,8 +88,9 @@ class InitController:
 
     def validate_conjur_url(self, conjur_url):
         """
-        Method for validating the Conjur server URL to
-        ensure it is provided as expected
+        Validates the specified url
+
+        Raises a RuntimeError in case of an invalid url format
         """
         if conjur_url.scheme != 'https':
             raise RuntimeError(f"Error: undefined behavior. Reason: The Conjur URL format provided "
@@ -98,7 +99,11 @@ class InitController:
     # pylint: disable=line-too-long
     def get_server_certificate(self, conjur_url):
         """
-        Method to get the certificate from the Conjur endpoint detailed by the user
+        Get the certificate from the specified conjur_url
+
+        Returns:
+            tuple of certificate fingerprint and certificate chains or
+            None if the user provided a certificate
         """
         if self.conjurrc_data.cert_file is not None:
             # Return None because we do not need to fetch the certificate

--- a/conjur/controller/login_controller.py
+++ b/conjur/controller/login_controller.py
@@ -29,7 +29,8 @@ class LoginController:
         """
         self.ssl_verify = ssl_verify
         if self.ssl_verify is False:
-            util_functions.get_insecure_warning()
+            util_functions.get_insecure_warning_in_debug()
+            util_functions.get_insecure_warning_in_warning()
 
         self.user_password = user_password
         self.credential_data = credential_data

--- a/conjur/logic/init_logic.py
+++ b/conjur/logic/init_logic.py
@@ -49,8 +49,9 @@ class InitLogic:
     @classmethod
     def fetch_account_from_server(cls, conjurrc_data):
         """
-        Fetches the account from the DAP server by making a request to the /info endpoint.
-        This endpoint only exists in the DAP server
+        Fetches the account from the Conjur Enterprise server by making a
+        request to the /info endpoint. This endpoint only exists in the
+        Conjur Enterprise server
         """
         params = {
             'url': conjurrc_data.conjur_url

--- a/conjur/util/util_functions.py
+++ b/conjur/util/util_functions.py
@@ -8,13 +8,14 @@ This module holds the common logic across the codebase
 import logging
 import os
 
-
-def get_insecure_warning():
+def get_insecure_warning_in_warning():
     """ Log warning message"""
     logging.warning("You chose to initialize the client in insecure mode. "
                     "If you prefer to communicate with the server securely, "
                     "you must reinitialize the client in secure mode.")
 
+def get_insecure_warning_in_debug():
+    """ Log debug message"""
     logging.debug("Warning: Running the command with '--insecure' "
                   "makes your system vulnerable to security attacks")
 

--- a/conjur/util/util_functions.py
+++ b/conjur/util/util_functions.py
@@ -11,8 +11,12 @@ import os
 
 def get_insecure_warning():
     """ Log warning message"""
-    logging.debug("Warning: Running the command with '--insecure'"
-                  " makes your system vulnerable to security attacks")
+    logging.warning("You chose to initialize the client in insecure mode. "
+                    "If you prefer to communicate with the server securely, "
+                    "you must reinitialize the client in secure mode.")
+
+    logging.debug("Warning: Running the command with '--insecure' "
+                  "makes your system vulnerable to security attacks")
 
 def determine_status_code_specific_error_messages(server_error):
     """ Method for returning status code-specific error messages """

--- a/conjur/wrapper/http_wrapper.py
+++ b/conjur/wrapper/http_wrapper.py
@@ -12,6 +12,7 @@ import re
 from enum import Enum
 from urllib.parse import quote
 import requests
+import urllib3
 
 from conjur.errors import CertificateHostnameMismatchException
 
@@ -36,6 +37,7 @@ def invoke_endpoint(http_verb, endpoint, params, *args, check_errors=True,
     """
     This method flexibly invokes HTTP calls from 'requests' module
     """
+    urllib3.disable_warnings()
     orig_params = params or {}
     # Escape all params
     params = {}

--- a/test/test_integration_credentials_keyring.py
+++ b/test/test_integration_credentials_keyring.py
@@ -94,6 +94,18 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
         self.assertEquals(utils.is_netrc_exists(), False)
 
     '''
+    Validates that if a user runs in insecure mode without supplying inputs, 
+    we will ask for them and successfully initialize the client
+    '''
+    @integration_test(True)
+    def test_cli_configured_in_insecure_mode_with_params_and_passes_keyring(self):
+        with patch('builtins.input', side_effect=[self.client_params.hostname, self.client_params.account, 'yes']):
+            output = self.invoke_cli(self.cli_auth_params,
+                            ['--insecure', 'init'])
+
+        self.assertRegex(output, 'To start using the Conjur CLI')
+
+    '''
     Validates a user can log in with a password, instead of their API key
     To do this, we perform the following:
     '''

--- a/test/test_integration_credentials_keyring.py
+++ b/test/test_integration_credentials_keyring.py
@@ -75,8 +75,6 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
         self.assertIn("The client was initialized without", output)
         self.assertEquals(utils.is_netrc_exists(), False)
 
-    test_cli_configured_in_insecure_mode_but_run_in_secure_mode_raises_error_keyring.tester=True
-
     '''
     Validates that if a user configures the CLI in insecure mode and runs a command in 
     insecure mode, then they will succeed
@@ -99,9 +97,11 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
     '''
     @integration_test(True)
     def test_cli_configured_in_insecure_mode_with_params_and_passes_keyring(self):
-        with patch('builtins.input', side_effect=[self.client_params.hostname, self.client_params.account, 'yes']):
+        utils.remove_file(DEFAULT_CONFIG_FILE)
+        utils.remove_file(DEFAULT_CERTIFICATE_FILE)
+        with patch('builtins.input', side_effect=[self.client_params.hostname, self.client_params.account]):
             output = self.invoke_cli(self.cli_auth_params,
-                            ['--insecure', 'init'])
+                                    ['--insecure', 'init'])
 
         self.assertRegex(output, 'To start using the Conjur CLI')
 

--- a/test/test_unit_client.py
+++ b/test/test_unit_client.py
@@ -128,15 +128,17 @@ class ClientTest(unittest.TestCase):
             url='http://myurl',
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.Api')
-    def test_client_performs_password_api_login_if_password_is_provided(self, mock_api_instance):
+    def test_client_performs_password_api_login_if_password_is_provided(self, mock_api_instance, mock_accessible):
         Client(url='http://foo', account='myacct', login_id='mylogin',
                password='mypass')
 
         mock_api_instance.return_value.login.assert_called_once_with('mylogin', 'mypass')
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.Api')
-    def test_client_initializes_client_with_api_key_if_its_provided(self, mock_api_instance):
+    def test_client_initializes_client_with_api_key_if_its_provided(self, mock_api_instance, mock_accessible):
         Client(url='http://foo', account='myacct', login_id='mylogin',
                api_key='someapikey')
 
@@ -150,11 +152,12 @@ class ClientTest(unittest.TestCase):
             url='http://foo',
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_performs_no_api_login_if_password_is_not_provided(self, mock_api_instance, mock_creds,
-                                                                      mock_api_config):
+                                                                      mock_api_config, mock_accessible):
         Client(url='http://foo', account='myacct', login_id='mylogin')
 
         mock_api_instance.return_value.login.assert_not_called()
@@ -208,11 +211,12 @@ class ClientTest(unittest.TestCase):
             url='http://foo',
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_config_from_apiconfig_if_password_is_not_provided(self, mock_api_instance, mock_creds,
-                                                                             mock_api_config):
+                                                                             mock_api_config, mock_accessible):
         Client(url='http://foo', account='myacct', login_id='mylogin')
 
         mock_api_instance.assert_called_with(
@@ -227,11 +231,12 @@ class ClientTest(unittest.TestCase):
             url='http://foo',
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_overrides_apiconfig_value_with_explicitly_provided_ones(self, mock_api_instance, mock_creds,
-                                                                            mock_api_config):
+                                                                            mock_api_config, mock_accessible):
         Client(url='http://foo', account='myacct', login_id='mylogin',
                ca_bundle='mybundle')
 
@@ -247,11 +252,12 @@ class ClientTest(unittest.TestCase):
             url='http://foo',
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_does_not_override_apiconfig_values_with_empty_values(self, mock_api_instance, mock_creds,
-                                                                         mock_api_config):
+                                                                         mock_api_config, mock_accessible):
         Client(url=None, account=None, login_id=None, ca_bundle=None)
 
         mock_api_instance.assert_called_with(
@@ -268,6 +274,7 @@ class ClientTest(unittest.TestCase):
 
     ### API passthrough tests ###
 
+
     @patch('conjur.api.client.Api')
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('logging.basicConfig')
@@ -277,31 +284,34 @@ class ClientTest(unittest.TestCase):
 
         mock_logging.assert_called_once_with(format=Client.LOGGING_FORMAT, level=logging.DEBUG)
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_api_get_variable_params(self, mock_api_instance, mock_creds,
-                                                           mock_api_config):
+                                                           mock_api_config, mock_accessible):
         Client().get('variable_id')
 
         mock_api_instance.return_value.get_variable.assert_called_once_with('variable_id', None)
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_returns_get_variable_result(self, mock_api_instance, mock_creds,
-                                                mock_api_config):
+                                                mock_api_config, mock_accessible):
         variable_value = uuid.uuid4().hex
         mock_api_instance.return_value.get_variable.return_value = variable_value
 
         return_value = Client().get('variable_id')
         self.assertEquals(return_value, variable_value)
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_api_get_many_variables_params(self, mock_api_instance, mock_creds,
-                                                                 mock_api_config):
+                                                                 mock_api_config, mock_accessible):
         Client().get_many('variable_id', 'variable_id2')
 
         mock_api_instance.return_value.get_variables.assert_called_once_with(
@@ -309,22 +319,24 @@ class ClientTest(unittest.TestCase):
             'variable_id2'
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_returns_get_variables_result(self, mock_api_instance, mock_creds,
-                                                 mock_api_config):
+                                                 mock_api_config, mock_accessible):
         variable_values = uuid.uuid4().hex
         mock_api_instance.return_value.get_variables.return_value = variable_values
 
         return_value = Client().get_many('variable_id', 'variable_id2')
         self.assertEquals(return_value, variable_values)
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_api_set_variable_params(self, mock_api_instance, mock_creds,
-                                                           mock_api_config):
+                                                           mock_api_config, mock_accessible):
         Client().set('variable_id', 'variable_value')
 
         mock_api_instance.return_value.set_variable.assert_called_once_with(
@@ -332,11 +344,12 @@ class ClientTest(unittest.TestCase):
             'variable_value',
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_api_load_policy_params(self, mock_api_instance, mock_creds,
-                                                          mock_api_config):
+                                                          mock_api_config, mock_accessible):
         Client().load_policy_file('name', 'policy')
 
         mock_api_instance.return_value.load_policy_file.assert_called_once_with(
@@ -344,21 +357,24 @@ class ClientTest(unittest.TestCase):
             'policy',
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
-    def test_client_returns_load_policy_result(self, mock_api_instance, mock_creds, mock_api_config):
+    def test_client_returns_load_policy_result(self, mock_api_instance, mock_creds,
+                                               mock_api_config, mock_accessible):
         load_policy_result = uuid.uuid4().hex
         mock_api_instance.return_value.load_policy_file.return_value = load_policy_result
 
         return_value = Client().load_policy_file('name', 'policy')
         self.assertEquals(return_value, load_policy_result)
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_api_replace_policy_params(self, mock_api_instance, mock_creds,
-                                                             mock_api_config):
+                                                             mock_api_config, mock_accessible):
         Client().replace_policy_file('name', 'policy')
 
         mock_api_instance.return_value.replace_policy_file.assert_called_once_with(
@@ -366,22 +382,24 @@ class ClientTest(unittest.TestCase):
             'policy'
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
-    def test_client_returns_replace_policy_result(self, mock_api_instance, mock_creds,
-                                                  mock_api_config):
-        replace_policy_result = uuid.uuid4().hex
-        mock_api_instance.return_value.replace_policy_file.return_value = replace_policy_result
+    def test_client_returns_replace_policy_result(self, mock_api_instance,
+                                                  mock_api_config, mock_accessible):
+        with patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials):
+            replace_policy_result = uuid.uuid4().hex
+            mock_api_instance.return_value.replace_policy_file.return_value = replace_policy_result
 
-        return_value = Client().replace_policy_file('name', 'policy')
-        self.assertEquals(return_value, replace_policy_result)
+            return_value = Client().replace_policy_file('name', 'policy')
+            self.assertEquals(return_value, replace_policy_result)
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_api_update_policy_params(self, mock_api_instance, mock_creds,
-                                                            mock_api_config):
+                                                            mock_api_config, mock_accessible):
         Client().update_policy_file('name', 'policy')
 
         mock_api_instance.return_value.update_policy_file.assert_called_once_with(
@@ -389,59 +407,65 @@ class ClientTest(unittest.TestCase):
             'policy'
         )
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_returns_update_policy_result(self, mock_api_instance, mock_creds,
-                                                 mock_api_config):
+                                                 mock_api_config, mock_accessible):
         update_policy_result = uuid.uuid4().hex
         mock_api_instance.return_value.update_policy_file.return_value = update_policy_result
 
         return_value = Client().update_policy_file('name', 'policy')
         self.assertEquals(return_value, update_policy_result)
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_resource_list_method(self, mock_api_instance, mock_creds,
-                                                        mock_api_config):
+                                                        mock_api_config, mock_accessible):
         Client().list({})
 
         mock_api_instance.return_value.resources_list.assert_called_once_with({})
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_whoami_method(self, mock_api_instance, mock_creds,
-                                                 mock_api_config):
+                                                 mock_api_config, mock_accessible):
         Client().whoami()
 
         mock_api_instance.return_value.whoami.assert_called_once_with()
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_api_rotate_other_api_key_params(self, mock_api_instance, mock_creds,
-                                                                   mock_api_config):
+                                                                   mock_api_config, mock_accessible):
         Client().rotate_other_api_key(MOCK_RESOURCE)
 
         mock_api_instance.return_value.rotate_other_api_key.assert_called_once_with(MOCK_RESOURCE)
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_api_rotate_personal_api_key_params(self, mock_api_instance, mock_creds,
-                                                                      mock_api_config):
+                                                                      mock_api_config, mock_accessible):
         Client().rotate_personal_api_key("someloggedinuser", "somecurrentpassword")
 
         mock_api_instance.return_value.rotate_personal_api_key.assert_called_once_with("someloggedinuser",
                                                                                        "somecurrentpassword")
 
+    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     def test_client_passes_through_api_change_password_params(self, mock_api_instance, mock_creds,
-                                                              mock_api_config):
+                                                              mock_api_config, mock_accessible):
         Client().change_personal_password("someloggedinuser", "somecurrentpassword", "somenewpassword")
 
         mock_api_instance.return_value.change_personal_password.assert_called_once_with("someloggedinuser",

--- a/test/test_unit_init_controller.py
+++ b/test/test_unit_init_controller.py
@@ -19,6 +19,7 @@ MockConjurrcData = ConjurrcData(conjur_url=TEST_HOSTNAME, account="admin")
 class MOCK_FORMATTED_URL:
     hostname = MockConjurrcData.conjur_url
     port = 443
+    scheme = "somescheme"
 
 class InitControllerTest(unittest.TestCase):
     capture_stream = io.StringIO()
@@ -151,7 +152,7 @@ class InitControllerTest(unittest.TestCase):
         mock_conjurrc_data = ConjurrcData(conjur_url=None)
         with self.assertRaises(RuntimeError) as context:
             init_controller = InitController(mock_conjurrc_data, self.init_logic, self.force_overwrite, self.ssl_verify)
-            init_controller.get_conjur_server_url()
+            init_controller.get_conjur_url()
         self.assertRegex(str(context.exception), 'Error: URL is required')
 
     @patch('builtins.input', return_value=MockConjurrcData.conjur_url)
@@ -159,7 +160,7 @@ class InitControllerTest(unittest.TestCase):
         mock_conjurrc_data = ConjurrcData(conjur_url='somehost')
         with self.assertRaises(RuntimeError) as context:
             init_controller = InitController(mock_conjurrc_data, self.init_logic, self.force_overwrite, self.ssl_verify)
-            init_controller.format_conjur_server_url()
+            init_controller.validate_conjur_url(MOCK_FORMATTED_URL)
         self.assertRegex(str(context.exception), 'Error: undefined behavior')
 
     @patch('builtins.input', return_value='no')

--- a/test/test_unit_init_controller.py
+++ b/test/test_unit_init_controller.py
@@ -152,7 +152,7 @@ class InitControllerTest(unittest.TestCase):
         mock_conjurrc_data = ConjurrcData(conjur_url=None)
         with self.assertRaises(RuntimeError) as context:
             init_controller = InitController(mock_conjurrc_data, self.init_logic, self.force_overwrite, self.ssl_verify)
-            init_controller.get_conjur_url()
+            init_controller.prompt_for_conjur_url()
         self.assertRegex(str(context.exception), 'Error: URL is required')
 
     @patch('builtins.input', return_value=MockConjurrcData.conjur_url)

--- a/test/test_unit_keystore_credentials_provider.py
+++ b/test/test_unit_keystore_credentials_provider.py
@@ -99,7 +99,7 @@ class KeystoreCredentialsProviderTest(unittest.TestCase):
     @patch.object(KeystoreAdapter, "get_keyring_name", return_value=TEST_KEYRING)
     def test_remove_credentials_raises_keyring_error_when_delete_password_raises_keyring_error(self,
                                                                                                mock_keystore_adapter,
-                                                                                               another_mock_keystore_adatper):
+                                                                                               another_mock_keystore_adapter):
         credential_provider = KeystoreCredentialsProvider()
         with self.assertRaises(keyring.errors.KeyringError):
             credential_provider.remove_credentials(MockConjurrcData)

--- a/test/test_unit_login_controller.py
+++ b/test/test_unit_login_controller.py
@@ -36,9 +36,9 @@ class LoginControllerTest(unittest.TestCase):
 
     def test_login_controller_constructor_with_ssl_verify_false_calls_warning_message(self):
         mock_ssl_verify = False
-        util_functions.get_insecure_warning = MagicMock()
+        util_functions.get_insecure_warning_in_debug = MagicMock()
         LoginController(mock_ssl_verify, None, None, None)
-        util_functions.get_insecure_warning.assert_called_once()
+        util_functions.get_insecure_warning_in_debug.assert_called_once()
 
     def test_login_load_calls_all_functions_correctly(self):
         mock_credential_data = CredentialsData


### PR DESCRIPTION
Previously when a user was running in insecure mode and not supplying the url, they would get an error "Invalid URL 'None/info': No schema supplied. Perhaps you meant http://None/info?". This fixes this by extracting the request for the URL from the certificate logic

conjur insecure init 
Returns error

conjur insecure init -u https://conjur-server
Return success

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation