### PR TITLE
Enable push to pypi and document breaking changes in SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-api-python3#101](https://github.com/cyberark/conjur-api-python3/issues/101)
 - The `user` methods 'rotate-api-key' and 'change-password' are now available in CLI and SDK to manage users
   [cyberark/conjur-api-python3#101](https://github.com/cyberark/conjur-api-python3/issues/101)
-- Add ability to get previous variable/secret versions. This is available in both CLI and SDK
+- Previous versions of a variable/secret can now be retrieved. This is available in both CLI and SDK
   [cyberark/conjur-api-python3#151](https://github.com/cyberark/conjur-api-python3/issues/151)
 - The `list` flag constraints are now available in both CLI and SDK to filter resource results
   [cyberark/conjur-api-python3#128](https://github.com/cyberark/conjur-api-python3/issues/91)
@@ -21,14 +21,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-api-python3#89](https://github.com/cyberark/conjur-api-python3/issues/89)
 
 ### Changed
+- The CLI and SDK now use a system's native credential store to save credentials instead of a netrc file by default. 
+  If a store is not available, the credentials will be saved to the netrc as a fallback.
 - The .conjurrc parameters have been renamed from `account` to `conjur_account` and from `appliance_url` to `conjur_url`.
   Additionally, the plugins parameter has been removed. This is a breaking change for users who generate their own
   .conjurrc file for use in the SDK and will need to update accordingly.
   [cyberark/conjur-api-python3#206](https://github.com/cyberark/conjur-api-python3/issues/206)
+- Policy functions `apply_policy_file` and `delete_policy_file` have been replaced with `load_policy_file` and 
+  `update_policy_file` respectively. This is a breaking change and users who import the SDK will need to update 
+  these references in their projects [cyberark/conjur-api-python3#112](https://github.com/cyberark/conjur-api-python3/issues/112)
 - CLI command UX has been improved according to UX guidelines
   [cyberark/conjur-api-python3#132](https://github.com/cyberark/conjur-api-python3/issues/132)
   See [design guidelines](https://ljfz3b.axshare.com/#id=x8ktq8&p=conjur_help__init&g=1)
-- Update version from 0.x.x to 7.0.0 to prep for the GA release
 - Update help screens according to [these guidelines](https://ljfz3b.axshare.com/#id=yokln4&p=conjur_main_help&g=1).
   [cyberark/conjur-api-python3#92](https://github.com/cyberark/conjur-api-python3/issues/92)
 - Directory structure has been refactored. See [design document](https://github.com/cyberark/conjur-api-python3/blob/master/design/general_refactorings.md) for more details.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,19 +49,18 @@ pipeline {
         }
       }
     }
-    // Temporarily comment this out until either the SDK is GA or the two use-cases are separated
     // Only publish if the HEAD is tagged with the same version as in __version__.py
     stage('Publish') {
       parallel {
-        //stage('Publish to PyPI') {
-        //  steps {
-        //    sh 'summon -e production ./bin/publish_package'
-        //  }
+        stage('Publish to PyPI') {
+          steps {
+            sh 'summon -e production ./bin/publish_package'
+          }
 
-        //  when {
-        //    branch "master"
-        //  }
-        //}
+          when {
+            branch "master"
+          }
+        }
 
         stage('Publish containers') {
           steps {

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
         "nose2>=0.9.2",
         "nose2[coverage_plugin]>=0.6.5",
         "pylint>=2.6.0",
+        "cryptography~=3.3.2",
+        "keyring>=23.0.0",
         "pyopenssl>=20.0.0",
         "PyInstaller>=4.0",
         "PyYAML>=5.3.1",


### PR DESCRIPTION
### What does this PR do?

Previously we decided that we were not going to push to Pypi because only the CLI is being promoted to GA and the pushed package includes both the CLI and SDK. Now, we changed this decision and will now push to Pypi and detail that the SDK will remain a Community-level project so that all will continue to benefit from the project's developments. 

This commit also adds entries to the CHANGELOG to detail all breaking changes.

Overturns decision to not push to Pypi: https://github.com/cyberark/conjur-api-python3/pull/212/files

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation