### PR TITLE
Removed unnecessary netrc and conjurrc creation in integration tests

### DIFF
--- a/test/test_integration_credentials_netrc.py
+++ b/test/test_integration_credentials_netrc.py
@@ -73,7 +73,7 @@ class CliIntegrationTestCredentialsNetrc(IntegrationTestCaseBase):
     '''
     Validates that when a user already logged in and reattempts and fails, the previous successful session is not removed
     '''
-    @integration_test(True)
+    @integration_test()
     def test_https_netrc_was_not_overwritten_when_login_failed_but_already_logged_in(self, keystore_disable_mock):
         utils.setup_cli(self)
         successful_run = self.invoke_cli(self.cli_auth_params,
@@ -88,7 +88,7 @@ class CliIntegrationTestCredentialsNetrc(IntegrationTestCaseBase):
     '''
     Validates logout doesn't remove another entry not associated with the current login
     '''
-    @integration_test(True)
+    @integration_test()
     def test_https_logout_successful_netrc(self, keystore_disable_mock):
         utils.setup_cli(self)
         self.invoke_cli(self.cli_auth_params,
@@ -106,7 +106,7 @@ class CliIntegrationTestCredentialsNetrc(IntegrationTestCaseBase):
     Validates when a user attempts to logout after an already 
     successful logout, will fail
     '''
-    @integration_test(True)
+    @integration_test()
     def test_https_logout_twice_returns_could_not_logout_message_netrc(self, keystore_disable_mock):
         utils.setup_cli(self)
         self.invoke_cli(self.cli_auth_params,
@@ -125,7 +125,7 @@ class CliIntegrationTestCredentialsNetrc(IntegrationTestCaseBase):
     '''
     Validate correct message when try to logout already logout user
     '''
-    @integration_test(True)
+    @integration_test()
     def test_no_netrc_and_logout_returns_successful_logout_message_netrc(self, keystore_disable_mock):
         utils.setup_cli(self)
         try:
@@ -330,7 +330,7 @@ class CliIntegrationTestCredentialsNetrc(IntegrationTestCaseBase):
     '''
     Validates logout doesn't remove an irrelevant entry
     '''
-    @integration_test(True)
+    @integration_test()
     def test_https_netrc_does_not_remove_irrelevant_entry_netrc(self, keystore_disable_mock):
         utils.setup_cli(self)
         creds = CredentialsData(self.client_params.hostname, "admin", self.client_params.env_api_key)

--- a/test/util/test_runners/integrations_tests_runner.py
+++ b/test/util/test_runners/integrations_tests_runner.py
@@ -4,6 +4,21 @@ The purpose of this file is to be a cross platform tests runner
 for all integration tests
 """
 
+# *************** DEVELOPER NOTE ***************
+# We have the ability to run our tests as a process which means we can run our tests as a user would,
+# without Python on the machine, using the Conjur CLI exec a customer would. Currently, some tests still
+# cannot run as a process. Tests that meet the following criteria cannot be run as a process and are given
+# the integration_test() decorator:
+# 1. any test that contains of error/stderr
+# 2. any test that runs a command that uses getpass (login and user commands)
+# 3. any test that has assertEquals. All new tests should use assertIn
+# 4. any test that uses a tmp file (policy command)
+# 5. any test that uses contents returned from invoke_cli
+# 6. any test that depends on keyring disable (mainly in CliIntegrationTestCredentialsNetrc)
+#
+# The main reason for these limitations is that we run in debug mode and all items that are printed to the
+# screen are captured.
+
 # Builtins
 import sys
 import os

--- a/test/util/test_runners/test_runner_args.py
+++ b/test/util/test_runners/test_runner_args.py
@@ -1,20 +1,6 @@
 from argparse import ArgumentParser
 
 
-# *************** DEVELOPER NOTE ***************
-# We have the ability to run our tests as a process which means we can run our tests as a user would,
-# without Python on the machine, using the Conjur CLI exec a customer would. Currently, some tests still
-# cannot run as a process. Tests that meet the following criteria cannot be run as a process and are given
-# the integration_test() decorator:
-# 1. any test that contains of error/stderr
-# 2. any test that runs a command that uses getpass (login and user commands)
-# 3. any test that has assertEquals. All new tests should use assertIn
-# 4. any test that uses a tmp file (policy command)
-# 5. any test that uses contents returned from invoke_cli
-#
-# The main reason for these limitations is that we run in debug mode and all items that are printed to the
-# screen are captured.
-
 class TestRunnerArgs:
     """
     DTO to hold the tests environment arguments

--- a/test/util/test_runners/test_runner_args.py
+++ b/test/util/test_runners/test_runner_args.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 
+
 # *************** DEVELOPER NOTE ***************
 # We have the ability to run our tests as a process which means we can run our tests as a user would,
 # without Python on the machine, using the Conjur CLI exec a customer would. Currently, some tests still
@@ -19,7 +20,7 @@ class TestRunnerArgs:
     DTO to hold the tests environment arguments
     """
 
-    def __init__(self, run_oss_tests, url, account, login, password, invoke_cli_as_process,
+    def __init__(self, run_oss_tests, url, account, login, password,
                  cli_to_test: str, files_folder: str,
                  test_name_identifier="integration"):
         self.run_oss_tests = run_oss_tests
@@ -29,9 +30,9 @@ class TestRunnerArgs:
         self.password = password
         self.test_name_identifier = test_name_identifier
         # Tests
-        if invoke_cli_as_process and test_name_identifier == 'integration':
+        self.invoke_cli_as_process = cli_to_test is not None and len(cli_to_test)>0
+        if self.invoke_cli_as_process and test_name_identifier == 'integration':
             self.test_name_identifier = "test_with_process"
-        self.invoke_cli_as_process = invoke_cli_as_process
         self.cli_to_test = cli_to_test
         self.files_folder = files_folder
 
@@ -58,9 +59,6 @@ class TestRunnerArgs:
         # Add the arguments
         parser.add_argument('--oss', dest='run_oss_tests', action='store_true',
                             help='Added to run OSS-specific tests')
-        parser.add_argument('-p-invoke', '--invoke-cli-as-process', action='store_true',
-                            help='If added, integration tests will run as a process executable. Otherwise it will run '
-                                 'as code, requiring Python')
         parser.add_argument('-i', '--identifier', dest='test_name_identifier', action='store', default='integration',
                             help='the test method with this identifier will be run (integration by default).')
         parser.add_argument('-u', '--url', dest='url', action='store', default='https://conjur-https',


### PR DESCRIPTION
removed run_as_process argument. calculate this from if cli-to-test has a path

### What does this PR do?
- Removed unsused setups at the start of integration_test_runner.
- Removed invoke_cli_as_process cmd line arg.

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [-] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [-] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [-] This PR does not require updating any documentation