### PR TITLE
Fix broken master with version tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,16 +56,19 @@ pipeline {
           steps {
             sh 'summon -e production ./bin/publish_package'
           }
+          when {
+            tag "v*"
+          }
         }
 
         stage('Publish containers') {
           steps {
             sh './bin/publish_container'
           }
+          when {
+            branch "master"
+          }
         }
-      }
-      when {
-        tag "v*"
       }
     }
 


### PR DESCRIPTION
The building of a container was happening only on version bumps which made this inaccessible to the following stages. This reverts the creation of the container to occur on master builds

### What ticket does this PR close?
Resolves #-

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation