### PR TITLE
Update the init account description

### DIFF
--- a/conjur/cli.py
+++ b/conjur/cli.py
@@ -150,7 +150,7 @@ Copyright (c) 2021 CyberArk Software Ltd. All rights reserved.
         init_options.add_argument('-a', '--account', metavar='VALUE',
                                   action='store', dest='name',
                                   help='Provide Conjur account name. ' \
-                                       'Optional for Conjur Enterprise - overrides the value on the Conjur Enterprise server')
+                                       'Optional for Conjur Enterprise - overrides the value received from the Conjur Enterprise server')
         init_options.add_argument('-c', '--certificate', metavar='VALUE',
                                   action='store', dest='certificate',
                                   help='Optional- provide path to Conjur SSL certificate ' \


### PR DESCRIPTION
### What does this PR do?
The `account` description for the init command was confusing because it made it seem that we are overriding the actual account on the server when this is not the case. This change clarifies the wording.

### What ticket does this PR close?
Resolves #239
The rest of the items on the list were either previously closed or no longer relevant

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation