### PR TITLE
Change class naming from KeystoreAdapter to KeystoreWrapper

### DIFF
--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -18,7 +18,7 @@ from conjur.util import util_functions
 from conjur.api import Api
 from conjur.config import Config as ApiConfig
 from conjur.resource import Resource
-from conjur.wrapper import KeystoreAdapter
+from conjur.wrapper import KeystoreWrapper
 
 
 # pylint: disable=pointless-string-statement
@@ -148,7 +148,7 @@ class Client():
         Configures the logging for the client
         """
         # Suppress third party logs
-        KeystoreAdapter.configure_keyring_log_to_info()
+        KeystoreWrapper.configure_keyring_log_to_info()
 
         if debug:
             logging.basicConfig(level=logging.DEBUG, format=self.LOGGING_FORMAT)

--- a/conjur/errors.py
+++ b/conjur/errors.py
@@ -70,20 +70,20 @@ class CredentialRetrievalException(Exception):
         self.message = FETCH_CREDENTIALS_FAILURE_MESSAGE
         super().__init__(self.message)
 
-class KeyringAdapterGeneralError(Exception):
-    """ General Exception for Keyring Adapter """
+class KeyringWrapperGeneralError(Exception):
+    """ General Exception for Keyring Wrapper """
     def __init__(self, message=""):
         self.message = message
         super().__init__(self.message)
 
-class KeyringAdapterDeletionError(KeyringAdapterGeneralError):
-    """ Exception for Keyring Adapter when underlying deletion operation failed """
+class KeyringWrapperDeletionError(KeyringWrapperGeneralError):
+    """ Exception for Keyring Wrapper when underlying deletion operation failed """
     def __init__(self, message=""):
         self.message = message
         super().__init__(self.message)
 
-class KeyringAdapterSetError(KeyringAdapterGeneralError):
-    """ Exception for Keyring Adapter when underlying set operation failed """
+class KeyringWrapperSetError(KeyringWrapperGeneralError):
+    """ Exception for Keyring Wrapper when underlying set operation failed """
     def __init__(self, message=""):
         self.message = message
         super().__init__(self.message)

--- a/conjur/logic/credential_provider/credential_store_factory.py
+++ b/conjur/logic/credential_provider/credential_store_factory.py
@@ -12,7 +12,7 @@ from conjur.interface.credentials_store_interface import CredentialsStoreInterfa
 from conjur.logic.credential_provider.file_credentials_provider import FileCredentialsProvider
 from conjur.logic.credential_provider.keystore_credentials_provider \
     import KeystoreCredentialsProvider
-from conjur.wrapper import KeystoreAdapter
+from conjur.wrapper import KeystoreWrapper
 
 
 # pylint: disable=too-few-public-methods
@@ -27,10 +27,10 @@ class CredentialStoreFactory:
         """
         Factory method for determining which store to use
         """
-        if KeystoreAdapter.get_keyring_name() in SUPPORTED_BACKENDS:
+        if KeystoreWrapper.get_keyring_name() in SUPPORTED_BACKENDS:
             # If the keyring is unlocked then we will use it
-            if KeystoreAdapter.is_keyring_accessible():
+            if KeystoreWrapper.is_keyring_accessible():
                 # pylint: disable=line-too-long
-                return KeystoreCredentialsProvider(), f'{KeystoreAdapter.get_keyring_name()} credential store'
+                return KeystoreCredentialsProvider(), f'{KeystoreWrapper.get_keyring_name()} credential store'
 
         return FileCredentialsProvider(), DEFAULT_NETRC_FILE

--- a/conjur/wrapper/__init__.py
+++ b/conjur/wrapper/__init__.py
@@ -4,4 +4,4 @@ wrapper
 This module contains wrapper classes for third party libraries
 """
 from conjur.wrapper.argparse_wrapper import ArgparseWrapper
-from conjur.wrapper.keystore_adapter import KeystoreAdapter
+from conjur.wrapper.keystore_wrapper import KeystoreWrapper

--- a/conjur/wrapper/keystore_wrapper.py
+++ b/conjur/wrapper/keystore_wrapper.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-KeystoreAdapter module
+KeystoreWrapper module
 
 This module is a wrapper for the third-party keyring module used to get and set
 credentials in a system's keyring. This module allows us to easily swap out both
@@ -15,17 +15,17 @@ import logging
 import keyring
 
 # Internals
-from conjur.errors import KeyringAdapterDeletionError, KeyringAdapterGeneralError\
-    , KeyringAdapterSetError
+from conjur.errors import KeyringWrapperDeletionError, KeyringWrapperGeneralError\
+    , KeyringWrapperSetError
 from conjur.util.util_functions import configure_env_var_with_keyring
 
 # Function is called in the module so that before accessing the
 # system’s keyring, the environment will be configured correctly
 configure_env_var_with_keyring()
 
-class KeystoreAdapter:
+class KeystoreWrapper:
     """
-    KeystoreAdapter
+    KeystoreWrapper
 
     A class for wrapping used functionality from the keyring library
     """
@@ -38,10 +38,10 @@ class KeystoreAdapter:
         try:
             keyring.set_password(identifier, key, val)
         except keyring.errors.PasswordSetError as password_error:
-            raise KeyringAdapterSetError(f"Failed to set key '{key}' for identifier "
+            raise KeyringWrapperSetError(f"Failed to set key '{key}' for identifier "
                                          f"'{identifier}'") from password_error
         except Exception as exception:
-            raise KeyringAdapterGeneralError(message=f"General keyring error has occurred "
+            raise KeyringWrapperGeneralError(message=f"General keyring error has occurred "
                                                      f"(Failed to set '{key}')'") from exception
 
     # pylint: disable=try-except-raise
@@ -53,7 +53,7 @@ class KeystoreAdapter:
         try:
             return keyring.get_password(identifier, key)
         except Exception as exception:
-            raise KeyringAdapterGeneralError(message=f"General keyring error has occurred "
+            raise KeyringWrapperGeneralError(message=f"General keyring error has occurred "
                                                      f"(Failed to get '{key}')'") from exception
 
     # pylint: disable=try-except-raise
@@ -65,10 +65,10 @@ class KeystoreAdapter:
         try:
             keyring.delete_password(identifier, key)
         except keyring.errors.PasswordDeleteError as password_error:
-            raise KeyringAdapterDeletionError(f"Failed to delete key '{key}' for identifier "
+            raise KeyringWrapperDeletionError(f"Failed to delete key '{key}' for identifier "
                                               f"'{identifier}'") from password_error
         except Exception as exception:
-            raise KeyringAdapterGeneralError(message=f"General keyring error has occurred "
+            raise KeyringWrapperGeneralError(message=f"General keyring error has occurred "
                                                      f"(Failed to delete '{key}')'") from exception
     @classmethod
     def get_keyring_name(cls):

--- a/test/test_integration_credentials_keyring.py
+++ b/test/test_integration_credentials_keyring.py
@@ -384,7 +384,7 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
     @integration_test(True)
     def test_keyring_locked_after_login_will_raise_error_keyring(self):
         utils.setup_cli(self)
-        with patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False):
+        with patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False):
             self.invoke_cli(self.cli_auth_params, ['list'], exit_code=1)
 
     '''

--- a/test/test_integration_credentials_netrc.py
+++ b/test/test_integration_credentials_netrc.py
@@ -24,7 +24,7 @@ from conjur.constants import DEFAULT_NETRC_FILE, DEFAULT_CONFIG_FILE, DEFAULT_CE
 All tests require that the Keyring on the system's environment is not accessible. 
 This is required to validate that the CLI operates as expected under such conditions.
 """
-@patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+@patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
 class CliIntegrationTestCredentialsNetrc(IntegrationTestCaseBase):
     # *************** HELPERS ***************
     def __init__(self, testname, client_params=None, environment_params=None):

--- a/test/test_unit_client.py
+++ b/test/test_unit_client.py
@@ -128,7 +128,7 @@ class ClientTest(unittest.TestCase):
             url='http://myurl',
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.Api')
     def test_client_performs_password_api_login_if_password_is_provided(self, mock_api_instance, mock_accessible):
         Client(url='http://foo', account='myacct', login_id='mylogin',
@@ -136,7 +136,7 @@ class ClientTest(unittest.TestCase):
 
         mock_api_instance.return_value.login.assert_called_once_with('mylogin', 'mypass')
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.Api')
     def test_client_initializes_client_with_api_key_if_its_provided(self, mock_api_instance, mock_accessible):
         Client(url='http://foo', account='myacct', login_id='mylogin',
@@ -152,7 +152,7 @@ class ClientTest(unittest.TestCase):
             url='http://foo',
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -211,7 +211,7 @@ class ClientTest(unittest.TestCase):
             url='http://foo',
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -231,7 +231,7 @@ class ClientTest(unittest.TestCase):
             url='http://foo',
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -252,7 +252,7 @@ class ClientTest(unittest.TestCase):
             url='http://foo',
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -284,7 +284,7 @@ class ClientTest(unittest.TestCase):
 
         mock_logging.assert_called_once_with(format=Client.LOGGING_FORMAT, level=logging.DEBUG)
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -294,7 +294,7 @@ class ClientTest(unittest.TestCase):
 
         mock_api_instance.return_value.get_variable.assert_called_once_with('variable_id', None)
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -306,7 +306,7 @@ class ClientTest(unittest.TestCase):
         return_value = Client().get('variable_id')
         self.assertEquals(return_value, variable_value)
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -319,7 +319,7 @@ class ClientTest(unittest.TestCase):
             'variable_id2'
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -331,7 +331,7 @@ class ClientTest(unittest.TestCase):
         return_value = Client().get_many('variable_id', 'variable_id2')
         self.assertEquals(return_value, variable_values)
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -344,7 +344,7 @@ class ClientTest(unittest.TestCase):
             'variable_value',
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -357,7 +357,7 @@ class ClientTest(unittest.TestCase):
             'policy',
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -369,7 +369,7 @@ class ClientTest(unittest.TestCase):
         return_value = Client().load_policy_file('name', 'policy')
         self.assertEquals(return_value, load_policy_result)
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -382,7 +382,7 @@ class ClientTest(unittest.TestCase):
             'policy'
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.api.client.Api')
     def test_client_returns_replace_policy_result(self, mock_api_instance,
@@ -394,7 +394,7 @@ class ClientTest(unittest.TestCase):
             return_value = Client().replace_policy_file('name', 'policy')
             self.assertEquals(return_value, replace_policy_result)
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -407,7 +407,7 @@ class ClientTest(unittest.TestCase):
             'policy'
         )
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -419,7 +419,7 @@ class ClientTest(unittest.TestCase):
         return_value = Client().update_policy_file('name', 'policy')
         self.assertEquals(return_value, update_policy_result)
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -429,7 +429,7 @@ class ClientTest(unittest.TestCase):
 
         mock_api_instance.return_value.resources_list.assert_called_once_with({})
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -439,7 +439,7 @@ class ClientTest(unittest.TestCase):
 
         mock_api_instance.return_value.whoami.assert_called_once_with()
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -449,7 +449,7 @@ class ClientTest(unittest.TestCase):
 
         mock_api_instance.return_value.rotate_other_api_key.assert_called_once_with(MOCK_RESOURCE)
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')
@@ -460,7 +460,7 @@ class ClientTest(unittest.TestCase):
         mock_api_instance.return_value.rotate_personal_api_key.assert_called_once_with("someloggedinuser",
                                                                                        "somecurrentpassword")
 
-    @patch('conjur.wrapper.keystore_adapter.KeystoreAdapter.is_keyring_accessible', return_value=False)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
     @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
     @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
     @patch('conjur.api.client.Api')

--- a/test/test_unit_credential_store_factory.py
+++ b/test/test_unit_credential_store_factory.py
@@ -5,26 +5,26 @@ from unittest.mock import patch, call
 from conjur.constants import TEST_KEYRING
 from conjur.logic.credential_provider import CredentialStoreFactory, KeystoreCredentialsProvider, \
     FileCredentialsProvider
-from conjur.wrapper import KeystoreAdapter
+from conjur.wrapper import KeystoreWrapper
 
 
 class CredentialStoreFactoryTest(unittest.TestCase):
-    @patch.object(KeystoreAdapter, "get_keyring_name", return_value=TEST_KEYRING)
-    @patch.object(KeystoreAdapter, "is_keyring_accessible", return_value=True)
+    @patch.object(KeystoreWrapper, "get_keyring_name", return_value=TEST_KEYRING)
+    @patch.object(KeystoreWrapper, "is_keyring_accessible", return_value=True)
     def test_create_credential_store_returns_keystore_when_there_is_keyring_and_is_accessible(
-            self, mock_keystore_adapter, mock_another_keystore_adapter):
+            self, mock_keystore_wrapper, mock_another_keystore_wrapper):
         provider, _ = CredentialStoreFactory.create_credential_store()
         self.assertIsInstance(provider, KeystoreCredentialsProvider)
 
-    @patch.object(KeystoreAdapter, "get_keyring_name", return_value=None)
+    @patch.object(KeystoreWrapper, "get_keyring_name", return_value=None)
     def test_create_credential_store_returns_file_when_there_is_no_keyring(self,
-                                                                           mock_keystore_adapter):
+                                                                           mock_keystore_wrapper):
         provider, _ = CredentialStoreFactory.create_credential_store()
         self.assertIsInstance(provider, FileCredentialsProvider)
 
-    @patch.object(KeystoreAdapter, "get_keyring_name", return_value=TEST_KEYRING)
-    @patch.object(KeystoreAdapter, "is_keyring_accessible", return_value=False)
+    @patch.object(KeystoreWrapper, "get_keyring_name", return_value=TEST_KEYRING)
+    @patch.object(KeystoreWrapper, "is_keyring_accessible", return_value=False)
     def test_create_credential_store_returns_file_when_there_is_keyring_and_its_not_accessible(
-            self, mock_keystore_adapter, mock_another_keystore_adapter):
+            self, mock_keystore_wrapper, mock_another_keystore_wrapper):
         provider, _ = CredentialStoreFactory.create_credential_store()
         self.assertIsInstance(provider, FileCredentialsProvider)

--- a/test/test_unit_keystore_adapter.py
+++ b/test/test_unit_keystore_adapter.py
@@ -8,33 +8,33 @@ import keyring
 
 # Internal
 from conjur.constants import TEST_HOSTNAME
-from conjur.errors import KeyringAdapterGeneralError, KeyringAdapterDeletionError
+from conjur.errors import KeyringWrapperGeneralError, KeyringWrapperDeletionError
 from conjur.util import util_functions
-from conjur.wrapper import KeystoreAdapter
+from conjur.wrapper import KeystoreWrapper
 
 
-class KeystoreAdapterTest(unittest.TestCase):
+class KeystoreWrapperTest(unittest.TestCase):
     @patch.object(keyring, "delete_password")
     def test_delete_password_calls_keyring_delete_password(self, mock_keyring):
-        KeystoreAdapter.delete_password(TEST_HOSTNAME, "key")
+        KeystoreWrapper.delete_password(TEST_HOSTNAME, "key")
         mock_keyring.assert_called_once_with(TEST_HOSTNAME, "key")
 
     @patch.object(keyring, "delete_password", side_effect=keyring.errors.KeyringError)
     def test_delete_password_raises_keyring_error(self, mock_delete_password):
-        with self.assertRaises(KeyringAdapterGeneralError):
-            KeystoreAdapter.delete_password(TEST_HOSTNAME, "some_key")
+        with self.assertRaises(KeyringWrapperGeneralError):
+            KeystoreWrapper.delete_password(TEST_HOSTNAME, "some_key")
 
     @patch.object(keyring, "delete_password", side_effect=keyring.errors.PasswordDeleteError)
     def test_delete_password_raises_expected_exceptions(self, mock_delete_password):
-        with self.assertRaises(KeyringAdapterDeletionError):
-            KeystoreAdapter.delete_password(TEST_HOSTNAME, "some_key")
+        with self.assertRaises(KeyringWrapperDeletionError):
+            KeystoreWrapper.delete_password(TEST_HOSTNAME, "some_key")
 
     @patch.object(keyring, "get_password", return_value=None)
     def test_is_keyring_accessible_return_true_when_get_password(self, mock_keyring):
-        keyring_accessible = KeystoreAdapter.is_keyring_accessible()
+        keyring_accessible = KeystoreWrapper.is_keyring_accessible()
         mock_keyring.assert_called_once_with('test-system', 'test-accessibility')
         self.assertEquals(True, keyring_accessible)
 
     @patch.object(keyring, "get_password", side_effect=keyring.errors.KeyringError)
     def test_is_keyring_accessible_returns_false_on_keyring_error(self, mock_keyring):
-        self.assertEquals(False, KeystoreAdapter.is_keyring_accessible())
+        self.assertEquals(False, KeystoreWrapper.is_keyring_accessible())

--- a/test/test_unit_keystore_credentials_provider.py
+++ b/test/test_unit_keystore_credentials_provider.py
@@ -6,9 +6,9 @@ import keyring
 # Internal
 from conjur.constants import TEST_HOSTNAME, PASSWORD, LOGIN, MACHINE, TEST_KEYRING
 from conjur.data_object import CredentialsData, ConjurrcData
-from conjur.errors import OperationNotCompletedException, CredentialRetrievalException, KeyringAdapterGeneralError
+from conjur.errors import OperationNotCompletedException, CredentialRetrievalException, KeyringWrapperGeneralError
 from conjur.logic.credential_provider import KeystoreCredentialsProvider
-from conjur.wrapper import KeystoreAdapter
+from conjur.wrapper import KeystoreWrapper
 
 MockCredentials = CredentialsData(machine=TEST_HOSTNAME, login='somelogin', password='somepass')
 MockConjurrcData = ConjurrcData(conjur_url=TEST_HOSTNAME, account="admin")
@@ -16,8 +16,8 @@ MockConjurrcData = ConjurrcData(conjur_url=TEST_HOSTNAME, account="admin")
 
 class KeystoreCredentialsProviderTest(unittest.TestCase):
 
-    @patch.object(KeystoreAdapter, 'set_password')
-    def test_save_calls_methods_properly(self, mock_store_adapter):
+    @patch.object(KeystoreWrapper, 'set_password')
+    def test_save_calls_methods_properly(self, mock_store_wrapper):
         credential_provider = KeystoreCredentialsProvider()
         credential_provider.save(MockCredentials)
         calls = [
@@ -25,10 +25,10 @@ class KeystoreCredentialsProviderTest(unittest.TestCase):
             call(TEST_HOSTNAME, LOGIN, 'somelogin'),
             call(TEST_HOSTNAME, PASSWORD, 'somepass')
         ]
-        mock_store_adapter.assert_has_calls(calls)
+        mock_store_wrapper.assert_has_calls(calls)
 
-    @patch.object(KeystoreAdapter, 'set_password', side_effect=Exception)
-    def test_save_can_raise_operation_not_complete_exception(self, mock_store_adapter):
+    @patch.object(KeystoreWrapper, 'set_password', side_effect=Exception)
+    def test_save_can_raise_operation_not_complete_exception(self, mock_store_wrapper):
         with self.assertRaises(OperationNotCompletedException):
             credential_provider = KeystoreCredentialsProvider()
             credential_provider.save(MockCredentials)
@@ -40,9 +40,9 @@ class KeystoreCredentialsProviderTest(unittest.TestCase):
             credential_provider.load(TEST_HOSTNAME)
 
     @patch.object(KeystoreCredentialsProvider, 'is_exists', return_value=True)
-    @patch.object(KeystoreAdapter, "get_password", return_value="password")
+    @patch.object(KeystoreWrapper, "get_password", return_value="password")
     @patch.object(CredentialsData, "convert_dict_to_obj", return_value=MockCredentials)
-    def test_load_credentials_calls_get_password(self, mock_credentials_data, mock_store_adapter, mock_cred_provider):
+    def test_load_credentials_calls_get_password(self, mock_credentials_data, mock_store_wrapper, mock_cred_provider):
         credential_provider = KeystoreCredentialsProvider()
         credentials_data = credential_provider.load(TEST_HOSTNAME)
         calls = [
@@ -50,45 +50,45 @@ class KeystoreCredentialsProviderTest(unittest.TestCase):
             call(TEST_HOSTNAME, LOGIN),
             call(TEST_HOSTNAME, PASSWORD)
         ]
-        mock_store_adapter.assert_has_calls(calls)
+        mock_store_wrapper.assert_has_calls(calls)
         self.assertEquals(MockCredentials.machine, credentials_data.machine)
         self.assertEquals(MockCredentials.login, credentials_data.login)
         self.assertEquals(MockCredentials.password, credentials_data.password)
 
-    @patch.object(KeystoreAdapter, 'set_password')
-    def test_update_api_key_calls_methods_properly(self, mock_store_adapter):
-        # mock_store_adapter.set_password.return_value=None
+    @patch.object(KeystoreWrapper, 'set_password')
+    def test_update_api_key_calls_methods_properly(self, mock_store_wrapper):
+        # mock_store_wrapper.set_password.return_value=None
         credential_provider = KeystoreCredentialsProvider()
         credential_provider.update_api_key_entry('someusertoupdate', MockCredentials, 'newapikey')
         calls = [call(TEST_HOSTNAME, MACHINE, TEST_HOSTNAME),
                  call(TEST_HOSTNAME, LOGIN, 'someusertoupdate'),
                  call(TEST_HOSTNAME, PASSWORD, 'newapikey')]
-        mock_store_adapter.assert_has_calls(calls)
+        mock_store_wrapper.assert_has_calls(calls)
 
-    @patch.object(KeystoreAdapter, 'set_password', side_effect=Exception)
-    def test_update_api_key_can_raise_operation_not_complete_exception(self, mock_store_adapter):
+    @patch.object(KeystoreWrapper, 'set_password', side_effect=Exception)
+    def test_update_api_key_can_raise_operation_not_complete_exception(self, mock_store_wrapper):
         with self.assertRaises(OperationNotCompletedException):
             credential_provider = KeystoreCredentialsProvider()
             credential_provider.update_api_key_entry('someusertoupdate', MockCredentials, 'newapikey')
 
-    @patch.object(KeystoreAdapter, "get_password", return_value=None)
-    def test_is_exists_return_false_if_attr_not_exists(self, mock_store_adapter):
+    @patch.object(KeystoreWrapper, "get_password", return_value=None)
+    def test_is_exists_return_false_if_attr_not_exists(self, mock_store_wrapper):
         credential_provider = KeystoreCredentialsProvider()
         self.assertEquals(False, credential_provider.is_exists(TEST_HOSTNAME))
 
-    @patch.object(KeystoreAdapter, "get_password", return_value="password")
-    def test_is_exists_return_true_when_attr_exists(self, mock_store_adapter):
+    @patch.object(KeystoreWrapper, "get_password", return_value="password")
+    def test_is_exists_return_true_when_attr_exists(self, mock_store_wrapper):
         credential_provider = KeystoreCredentialsProvider()
         self.assertEquals(True, credential_provider.is_exists(TEST_HOSTNAME))
 
-    @patch.object(KeystoreAdapter, "get_password", side_effect=Exception)
-    def test_is_exists_raises_exception_when_exception_is_thrown_by_get_password(self, mock_store_adapter):
+    @patch.object(KeystoreWrapper, "get_password", side_effect=Exception)
+    def test_is_exists_raises_exception_when_exception_is_thrown_by_get_password(self, mock_store_wrapper):
         credential_provider = KeystoreCredentialsProvider()
         with self.assertRaises(Exception):
             credential_provider.is_exists(TEST_HOSTNAME)
 
-    @patch.object(KeystoreAdapter, "delete_password", return_value=None)
-    @patch.object(KeystoreAdapter, "get_keyring_name", return_value=TEST_KEYRING)
+    @patch.object(KeystoreWrapper, "delete_password", return_value=None)
+    @patch.object(KeystoreWrapper, "get_keyring_name", return_value=TEST_KEYRING)
     def test_remove_credentials_calls_delete_password_for_each_credential(self, mock_keyring_name,
                                                                           mock_delete_password):
         credential_provider = KeystoreCredentialsProvider()
@@ -98,18 +98,18 @@ class KeystoreCredentialsProviderTest(unittest.TestCase):
                  call(TEST_HOSTNAME, PASSWORD)]
         mock_delete_password.assert_has_calls(calls)
 
-    @patch.object(KeystoreAdapter, "delete_password", side_effect=KeyringAdapterGeneralError)
-    @patch.object(KeystoreAdapter, "get_keyring_name", return_value=TEST_KEYRING)
+    @patch.object(KeystoreWrapper, "delete_password", side_effect=KeyringWrapperGeneralError)
+    @patch.object(KeystoreWrapper, "get_keyring_name", return_value=TEST_KEYRING)
     def test_remove_credentials_raises_keyring_error_when_delete_password_raises_keyring_error(self,
-                                                                                               mock_keystore_adapter,
-                                                                                               another_mock_keystore_adapter):
+                                                                                               mock_keystore_wrapper,
+                                                                                               another_mock_keystore_wrapper):
         credential_provider = KeystoreCredentialsProvider()
         with self.assertRaises(Exception):
             credential_provider.remove_credentials(MockConjurrcData)
 
-    @patch.object(KeystoreAdapter, "get_password", return_value="somepassword")
-    @patch.object(KeystoreAdapter, "delete_password", return_value=None)
-    @patch.object(KeystoreAdapter, "get_keyring_name", return_value=TEST_KEYRING)
+    @patch.object(KeystoreWrapper, "get_password", return_value="somepassword")
+    @patch.object(KeystoreWrapper, "delete_password", return_value=None)
+    @patch.object(KeystoreWrapper, "get_keyring_name", return_value=TEST_KEYRING)
     def test_cleanup_calls_delete_for_each_attribute(self, mock_keyring_name, mock_delete_password, mock_get_password):
         credential_provider = KeystoreCredentialsProvider()
         credential_provider.remove_credentials(MockConjurrcData)


### PR DESCRIPTION
### What does this PR do?

This commit renames KeystoreAdapter -> KeystoreWrapper for the sake of better naming

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation