### PR TITLE
Add error handling when user uses older conjurrc

### DIFF
--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -101,13 +101,9 @@ class Client():
                                                        solution="To continue communicating with the server insecurely, run the command "
                                                                 "again with ssl_verify = False. Otherwise, reinitialize the client.") from cert_verify
             except ConfigurationMissingException as missing_config_exec:
-                raise ConfigurationMissingException("The conjurrc configuration file content is empty. Reinitialize "
-                                                   "the client and make sure that the conjurrc contains "
-                                                   "'conjur_account', 'conjur_url', and 'cert_file'.") from missing_config_exec
+                raise ConfigurationMissingException from missing_config_exec
             except InvalidConfigurationException as invalid_config_exec:
-                raise InvalidConfigurationException("The conjurrc configuration file is either invalid or missing parameters. "
-                                                    "Reinitialize the client and make sure that the conjurrc contains "
-                                                    "'conjur_account', 'conjur_url', and 'cert_file'.") from invalid_config_exec
+                raise InvalidConfigurationException from invalid_config_exec
             except Exception:
                 raise
 

--- a/conjur/config.py
+++ b/conjur/config.py
@@ -38,7 +38,6 @@ class Config():
 
     def __init__(self, config_file=DEFAULT_CONFIG_FILE):
         # pylint: disable=logging-fstring-interpolation
-
         logging.debug(f"Fetching connection details from filesystem '{config_file}'...")
         config = None
         with open(config_file, 'r') as config_fp:

--- a/conjur/data_object/conjurrc_data.py
+++ b/conjur/data_object/conjurrc_data.py
@@ -37,8 +37,8 @@ class ConjurrcData:
                 return ConjurrcData(loaded_conjurrc['conjur_url'],
                                     loaded_conjurrc['conjur_account'],
                                     loaded_conjurrc['cert_file'])
-        except KeyError:
-            raise InvalidConfigurationException
+        except KeyError as key_error:
+            raise InvalidConfigurationException from key_error
 
     # pylint: disable=line-too-long
     def __repr__(self):

--- a/conjur/data_object/conjurrc_data.py
+++ b/conjur/data_object/conjurrc_data.py
@@ -7,6 +7,7 @@ This module represents an object that holds conjurrc data
 """
 # pylint: disable=too-few-public-methods
 from yaml import load as yaml_load
+
 try:
     from yaml import CLoader as YamlLoader
 except ImportError: # pragma: no cover
@@ -14,6 +15,7 @@ except ImportError: # pragma: no cover
 
 # Internals
 from conjur.constants import DEFAULT_CONFIG_FILE
+from conjur.errors import InvalidConfigurationException
 
 class ConjurrcData:
     """
@@ -29,11 +31,14 @@ class ConjurrcData:
         """
         Method that loads the conjurrc into an object
         """
-        with open(conjurrc_path, 'r') as conjurrc:
-            loaded_conjurrc = yaml_load(conjurrc, Loader=YamlLoader)
-            return ConjurrcData(loaded_conjurrc['conjur_url'],
-                                loaded_conjurrc['conjur_account'],
-                                loaded_conjurrc['cert_file'])
+        try:
+            with open(conjurrc_path, 'r') as conjurrc:
+                loaded_conjurrc = yaml_load(conjurrc, Loader=YamlLoader)
+                return ConjurrcData(loaded_conjurrc['conjur_url'],
+                                    loaded_conjurrc['conjur_account'],
+                                    loaded_conjurrc['cert_file'])
+        except KeyError:
+            raise InvalidConfigurationException
 
     # pylint: disable=line-too-long
     def __repr__(self):

--- a/conjur/errors.py
+++ b/conjur/errors.py
@@ -55,14 +55,14 @@ class CertificateHostnameMismatchException(Exception):
 
 class InvalidConfigurationException(Exception):
     """ Exception for when configuration file (from .conjurrc) is in invalid format """
-    def __init__(self):
-        self.message = FETCH_CONFIGURATION_FAILURE_MESSAGE
+    def __init__(self, message=FETCH_CONFIGURATION_FAILURE_MESSAGE):
+        self.message = message
         super().__init__(self.message)
 
 class ConfigurationMissingException(Exception):
     """ Exception for when configuration is missing """
-    def __init__(self):
-        self.message = CONFIGURATION_MISSING_FAILURE_MESSAGE
+    def __init__(self, message=CONFIGURATION_MISSING_FAILURE_MESSAGE):
+        self.message = message
         super().__init__(self.message)
 
 class CredentialRetrievalException(Exception):

--- a/conjur/errors.py
+++ b/conjur/errors.py
@@ -5,7 +5,8 @@ Error module
 
 This module holds Conjur CLI/SDK-specific errors for this project
 """
-from conjur.errors_messages import MISMATCH_HOSTNAME_MESSAGE, FETCH_CREDENTIALS_FAILURE_MESSAGE
+from conjur.errors_messages import MISMATCH_HOSTNAME_MESSAGE, FETCH_CREDENTIALS_FAILURE_MESSAGE, \
+    FETCH_CONFIGURATION_FAILURE_MESSAGE, CONFIGURATION_MISSING_FAILURE_MESSAGE
 
 
 class InvalidPasswordComplexityException(Exception):
@@ -53,15 +54,15 @@ class CertificateHostnameMismatchException(Exception):
         super().__init__(self.message)
 
 class InvalidConfigurationException(Exception):
-    """ Exception for when configuration is invalid """
-    def __init__(self, message=""):
-        self.message = message
+    """ Exception for when configuration file (from .conjurrc) is in invalid format """
+    def __init__(self):
+        self.message = FETCH_CONFIGURATION_FAILURE_MESSAGE
         super().__init__(self.message)
 
 class ConfigurationMissingException(Exception):
     """ Exception for when configuration is missing """
-    def __init__(self, message=""):
-        self.message = message
+    def __init__(self):
+        self.message = CONFIGURATION_MISSING_FAILURE_MESSAGE
         super().__init__(self.message)
 
 class CredentialRetrievalException(Exception):

--- a/conjur/errors_messages.py
+++ b/conjur/errors_messages.py
@@ -20,3 +20,11 @@ MISMATCH_HOSTNAME_MESSAGE = "The machine's hostname did not match any names on t
                             "Make sure the names on the certificate (common name or SANs) match the machine's hostname."
 
 FETCH_CREDENTIALS_FAILURE_MESSAGE = "Failed to fetch credentials. Log in again and rerun the command."
+
+FETCH_CONFIGURATION_FAILURE_MESSAGE = "The conjurrc configuration file is either invalid or missing parameters. "\
+                                      "Reinitialize the client and make sure that the conjurrc contains "\
+                                      "'conjur_account', 'conjur_url', and 'cert_file'."
+
+CONFIGURATION_MISSING_FAILURE_MESSAGE = "The conjurrc configuration file content is empty. Reinitialize "\
+                                        "the client and make sure that the conjurrc contains "\
+                                        "'conjur_account', 'conjur_url', and 'cert_file'."

--- a/test/test_config/incorrect_format_conjurrc
+++ b/test/test_config/incorrect_format_conjurrc
@@ -1,0 +1,6 @@
+---
+account: accountname
+plugins: []
+appliance_url: https://someurl/somepath
+cert_file: "/cert/file/location"
+version: 4

--- a/test/test_unit_client.py
+++ b/test/test_unit_client.py
@@ -28,7 +28,7 @@ class MockApiConfig(object):
 # ApiConfig mocking class
 class EmptyMockApiConfig(object):
     def __init__(self):
-        raise ConfigurationMissingException("oops!")
+        raise ConfigurationMissingException
 
 # ApiConfig mocking class
 class MockApiConfigNoCert(object):
@@ -58,7 +58,7 @@ class MissingMockApiConfig(object):
 class ConfigErrorTest(unittest.TestCase):
     def test_config_exception_wrapper_exists(self):
         with self.assertRaises(ConfigurationMissingException):
-            raise ConfigurationMissingException('abc')
+            raise ConfigurationMissingException
 
 
 class ClientTest(unittest.TestCase):

--- a/test/test_unit_conjurrc_data.py
+++ b/test/test_unit_conjurrc_data.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import mock_open, patch
 
 from conjur.data_object.conjurrc_data import ConjurrcData
+from conjur.errors import InvalidConfigurationException
 
 EXPECTED_REP_OBJECT={'conjur_url': 'https://someurl', 'conjur_account': 'someaccount', 'cert_file': "/some/cert/path"}
 EXPECTED_CONJURRC = \
@@ -26,3 +27,9 @@ class ConjurrcDataTest(unittest.TestCase):
          with patch("builtins.open", mock_open(read_data=EXPECTED_CONJURRC)):
             mock_conjurrc_data = ConjurrcData.load_from_file()
             self.assertEquals(mock_conjurrc_data.__dict__, CONJURRC_DICT)
+
+    @patch('builtins.open', side_effect=KeyError)
+    def test_conjurrc_throws_error_when_key_is_missing(self, mock_open):
+        mock_conjurrc = ConjurrcData("https://someurl", "someaccount", "/some/cert/path")
+        with self.assertRaises(InvalidConfigurationException):
+            mock_conjurrc.load_from_file()

--- a/test/util/test_path_provider.py
+++ b/test/util/test_path_provider.py
@@ -51,6 +51,10 @@ class TestRunnerPathProvider():  # pragma: no cover
         return os.path.join(self.HELPERS_FILES_DIR, "test_config", "missing_account_conjurrc")
 
     @property
+    def test_incorrect_format_conjurrc(self):
+        return os.path.join(self.HELPERS_FILES_DIR, "test_config", "incorrect_format_conjurrc")
+
+    @property
     def test_insecure_conjurrc_file_path(self):
         return os.path.join(self.HELPERS_FILES_DIR, "test_config", "no_cert_conjurrc")
 


### PR DESCRIPTION
### What does this PR do?
When a user doesn't have the correct keys in their conjurrc config file (because of an older version of conjurrc when using the ruby cli), the user gets incomprehensive error. This fixes this by adding error handling and returning a more detailed error message.

Previously:
<img width="754" alt="Screen Shot 2021-05-16 at 11 34 28 AM" src="https://user-images.githubusercontent.com/19418506/118391034-f46bdc80-b63a-11eb-8254-0d7df0ce3d72.png">

With this change:
<img width="1409" alt="Screen Shot 2021-05-16 at 11 33 55 AM" src="https://user-images.githubusercontent.com/19418506/118391014-e0c07600-b63a-11eb-96b7-dcd414384761.png">

### What ticket does this PR close?
Resolves #292

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation