### PR TITLE
Add certificate information to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ output/*.xml
 coverage.xml
 .netrc
 .conjurrc
+*.key
+*.crt
 
 # Build artifacts
 build/


### PR DESCRIPTION
### What does this PR do?
.key and .crt files are generated when we run our tests suite locally. These files are only relevant locally and only during the lifecycle of the test environment containers. That being said, they shouldn't be pushed. This commit adds these two file extensions (.crt/.key) to the gitignore file so that we don't push them accidentally.

### What ticket does this PR close?
Resolves -