### PR TITLE
Fix broken build by ignoring linting error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,5 +109,14 @@ pipeline {
     always {
       cleanupAndNotify(currentBuild.currentResult)
     }
+    unsuccessful {
+      script {
+        if (env.BRANCH_NAME == 'master') {
+          cleanupAndNotify(currentBuild.currentResult, "#development", "@PalmTree")
+        } else {
+          cleanupAndNotify(currentBuild.currentResult, "#development")
+        }
+      }
+    }
   }
 }

--- a/conjur/api/ssl_client.py
+++ b/conjur/api/ssl_client.py
@@ -46,6 +46,7 @@ class SSLClient:
         return fingerprint, readable_certificate
 
     @classmethod
+    # pylint: disable=unused-private-member
     def __connect(cls, hostname: str, port: int) -> SSL.Connection:
         """
         Method for opening a socket to the Conjur server


### PR DESCRIPTION
### What does this PR do?
For the past few days the CLI build has been failing on a pylint error 
```
conjur/api/ssl_client.py:49: [W0238(unused-private-member), SSLClient.__connect] Unused private member `SSLClient.__connect(cls, hostname: str, port: int)
```
This is a false positive because we do use `SSL.Connection` that just started to be triggered. This commit fixes this by disabling the pylinter on this line and also tags PalmTree in notifications of broken builds

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation