### PR TITLE
Do not echo command with password

### DIFF
--- a/test/configure_test_executor.sh
+++ b/test/configure_test_executor.sh
@@ -35,7 +35,6 @@ function _tests_runner_cmd() {
     _cmd="$_cmd --login $LOGIN"
     _cmd="$_cmd --password $ADMIN_PASSWORD"
     _cmd="$_cmd --files-folder /opt/conjur-api-python3/test"
-  echo "$_cmd"
 }
 
 # Appends the 1st argumnet to the script file


### PR DESCRIPTION
### What does this PR do?
Although the password is generated, we should not print
it to the log as we may change it in the future to a
real secret (e.g the one from conjurops)

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation