### PR TITLE
Use admin password from ConjurOps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
 
     stage('RHEL8 Integration tests') {
       steps {
-        sh './bin/test_integration_rhel8'
+        sh 'summon -e common ./bin/test_integration_rhel8'
       }
 
       post {

--- a/bin/test_integration_rhel8
+++ b/bin/test_integration_rhel8
@@ -25,19 +25,7 @@ docker-compose up openssl
 echo "Starting Conjur..."
 docker-compose up -d conjur-appliance
 
-function _random_password() {
-  { </dev/urandom LC_ALL=C grep -ao '[A-Za-z0-9]' \
-        | head -n$((RANDOM % 12 + 9))
-    echo "@1"   # add a special char and digit.
-  } \
-    | shuf \
-    | tr -d '\n'
-}
-
 echo "Configuring Conjur..."
-set +x
-export ADMIN_PASSWORD=$(_random_password)
-set -x
 export DEBUG=$DEBUG
 export CONJUR_AUTHN_API_KEY=$ADMIN_PASSWORD
 export SERVER_MODE="appliance"

--- a/secrets.yml
+++ b/secrets.yml
@@ -1,3 +1,6 @@
+common:
+  ADMIN_PASSWORD: !var ci/generics/conjur-admin-password
+
 production:
   TWINE_REPOSITORY_URL: !var ecosystems/pypi/users/endpoint
   TWINE_USERNAME: !var ecosystems/pypi/users/conjur/username


### PR DESCRIPTION
### What does this PR do?
We prefer to use the admin password from ConjurOps
instead of generating one. This helps us also in the
complexity and also in referring to the password as
a secret

Resolves #301

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation