### PR TITLE
Fix Dockerfiles for linting

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -13,7 +13,8 @@ RUN apt-get update && \
                     python3-dev \
                     python3-pip \
                     gnome-keyring \
-                    dbus-x11
+                    dbus-x11 \
+                    zlib1g-dev
 
 RUN mkdir -p $INSTALL_DIR
 WORKDIR $INSTALL_DIR

--- a/Dockerfile.test.rhel8
+++ b/Dockerfile.test.rhel8
@@ -20,13 +20,15 @@ RUN yum --disableplugin=subscription-manager -y \
                                             gnome-keyring \
                                             dbus-x11 \
                                             procps \
+                                            zlib-devel \
          && yum --disableplugin=subscription-manager clean all
 
 RUN mkdir -p $INSTALL_DIR
 WORKDIR $INSTALL_DIR
 
 COPY ./requirements.txt $INSTALL_DIR/
-RUN pip3 install -r requirements.txt
+RUN pip3 install wheel && \
+    pip3 install -r requirements.txt
 
 COPY ./bin/build_integrations_tests_runner /build_integrations_tests_runner
 


### PR DESCRIPTION
### What does this PR do?
Test Dockerfile now install zlib.
Jenkins build was failing with the following logs in step `RUN pip3 install -r requirements.txt` in Dockerfile.test and Dockerfile.test.rhel8:

```
Building wheels for collected packages: PyInstaller, wrapt
15:12:02    Running setup.py bdist_wheel for PyInstaller: started
15:12:03    Running setup.py bdist_wheel for PyInstaller: finished with status 'error'
15:12:03    Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-vw8tvcbf/PyInstaller/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmp86smhxdipip-wheel- --python-tag cp36:
15:12:03    running bdist_wheel
15:12:03    running build
15:12:03    running build_bootloader
15:12:03    No precompiled bootloader found. Trying to compile it for you ...
15:12:03    Setting top to                           : /tmp/pip-build-vw8tvcbf/PyInstaller/bootloader
15:12:03    Setting out to                           : /tmp/pip-build-vw8tvcbf/PyInstaller/bootloader/build
15:12:03    Python Version                           : 3.6.9 (default, Jan 26 2021, 15:33:00) [GCC 8.4.0]
15:12:03    Checking for 'gcc' (C compiler)          : /usr/bin/gcc
15:12:03    Checking size of pointer                 : 8
15:12:03    Platform                                 : Linux-64bit-intel detected based on compiler
15:12:03    Checking for compiler flags -m64         : yes
15:12:03    Checking for linker flags -m64           : yes
15:12:03    Checking for library dl                  : yes
15:12:03    Checking for library pthread             : yes
15:12:03    Checking for library m                   : yes
15:12:03    Checking for library z                   : not found
15:12:03    The configuration failed
15:12:03    (complete log in /tmp/pip-build-vw8tvcbf/PyInstaller/bootloader/build/config.log)
15:12:03    ERROR: Failed compiling the bootloader. Please compile manually and rerun setup.py
```

Dockerfile.test.rhel8 now pip installs Wheel before PyInstaller in requirements.txt.
Jenkins build was failing with the following logs in step `RUN pip3 install -r requirements.txt` in Dockerfile.test.rhel8:

```
Collecting PyInstaller>=4.0 (from -r requirements.txt (line 8))
  Downloading https://files.pythonhosted.org/packages/56/68/fcf288abb7985d17c4d5802aa76cbc6e00cd85d084230338cf4ef8696a38/pyinstaller-4.4.tar.gz (3.8MB)
    Complete output from command python setup.py egg_info:
    Error: Building wheels requires the 'wheel' package. Please `pip install wheel` then try again.
```

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation