### PR TITLE
Fix Dockerfiles for publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && \
                        libssl-dev \
                        python3 \
                        python3-dev \
-                       python3-pip
+                       python3-pip \
+                       zlib1g-dev
 
 RUN mkdir -p $INSTALL_DIR
 WORKDIR $INSTALL_DIR

--- a/Dockerfile.publish
+++ b/Dockerfile.publish
@@ -11,7 +11,8 @@ RUN apt-get update && \
                     libssl-dev \
                     python3 \
                     python3-dev \
-                    python3-pip
+                    python3-pip \
+                    zlib1g-dev
 
 RUN mkdir -p $INSTALL_DIR
 WORKDIR $INSTALL_DIR


### PR DESCRIPTION
### What does this PR do?
Resolves similar Dockerfile build issues as in [conjur-api-python3#323](https://github.com/cyberark/conjur-api-python3/pull/323), this time in the Publish Jenkins stage.
Installs `zlib1g-dev` in `Dockerfile` and `Dockerfile.publish`.

### What ticket does this PR close?
Resolves main branch build failure.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation