### PR TITLE
Fix host example from command it does not support

### DIFF
--- a/conjur/api/api.py
+++ b/conjur/api/api.py
@@ -152,7 +152,6 @@ class Api():
         if list_constraints is not None and 'inspect' not in list_constraints:
             # For each element (resource) in the resources sequence, we extract the resource id
             resource_list = map(lambda resource: resource['id'], resources)
-            # TODO: Understand why list and not dict
             return list(resource_list)
 
         # To see the full resources response see

--- a/conjur/api/api.py
+++ b/conjur/api/api.py
@@ -19,6 +19,7 @@ from conjur.errors import InvalidResourceException, MissingRequiredParameterExce
 # pylint: disable=too-many-instance-attributes
 from conjur.resource import Resource
 
+# pylint: disable=unspecified-encoding
 class Api():
     """
     This module provides a high-level programmatic access to the HTTP API

--- a/conjur/argument_parser/_host_parser.py
+++ b/conjur/argument_parser/_host_parser.py
@@ -39,7 +39,7 @@ class HostParser:
                             'conjur host rotate-api-key -i my_apps/myVM\t\t'
                             'Rotates the API key for host myVM',
                             command='host',
-                            subcommands=['change-password']),
+                            subcommands=['rotate-api-key']),
                         usage=argparse.SUPPRESS,
                         add_help=False,
                         formatter_class=formatter)

--- a/conjur/config.py
+++ b/conjur/config.py
@@ -38,6 +38,7 @@ class Config():
 
     _config = {}
 
+    # pylint: disable=unspecified-encoding
     def __init__(self, config_file=DEFAULT_CONFIG_FILE):
         # pylint: disable=logging-fstring-interpolation
         logging.debug(f"Fetching connection details from filesystem '{config_file}'...")

--- a/conjur/data_object/conjurrc_data.py
+++ b/conjur/data_object/conjurrc_data.py
@@ -26,6 +26,7 @@ class ConjurrcData:
         self.conjur_account = account
         self.cert_file = cert_file
 
+    # pylint: disable=unspecified-encoding
     @classmethod
     def load_from_file(cls, conjurrc_path: str = DEFAULT_CONFIG_FILE):
         """

--- a/conjur/logic/credential_provider/file_credentials_provider.py
+++ b/conjur/logic/credential_provider/file_credentials_provider.py
@@ -20,7 +20,7 @@ from conjur.errors import CredentialRetrievalException, NotLoggedInException, In
 from conjur.interface.credentials_store_interface import CredentialsStoreInterface
 
 
-# pylint: disable=logging-fstring-interpolation, line-too-long
+# pylint: disable=logging-fstring-interpolation, line-too-long, unspecified-encoding
 class FileCredentialsProvider(CredentialsStoreInterface):
     """
     FileCredentialsProvider

--- a/conjur/logic/init_logic.py
+++ b/conjur/logic/init_logic.py
@@ -25,7 +25,7 @@ from conjur.errors import ConnectionToConjurFailedException,RetrieveCertificateE
 
 DEFAULT_PORT = 443
 
-# pylint: disable=raise-missing-from
+# pylint: disable=raise-missing-from,unspecified-encoding
 class InitLogic:
     """
     InitLogic


### PR DESCRIPTION
### What does this PR do?
The host command had a bug under 'examples' section where it was displaying 'change-password' instead of 'rotate-api-key' when host does not support the change-password command. This commit fixes that and also fixes the broken main build on pylint encoding suggestion

Bug:
<img width="501" alt="Screen Shot 2021-08-22 at 8 42 56" src="https://user-images.githubusercontent.com/19418506/130343896-2ed1eda7-6972-4305-82a3-e5c5232bcb46.png">
Fix:
<img width="504" alt="Screen Shot 2021-08-22 at 8 43 15" src="https://user-images.githubusercontent.com/19418506/130343911-960ba2a2-e517-4235-bbcf-6db5200ac48d.png">

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation