### PR TITLE
Log full error on policy load failure

### DIFF
--- a/conjur/controller/policy_controller.py
+++ b/conjur/controller/policy_controller.py
@@ -35,5 +35,8 @@ class PolicyController:
         except requests.exceptions.HTTPError as http_error:
             if http_error.response.status_code == 422:
                 raise InvalidFormatException(f"{http_error}. The policy was empty or its contents "
-                                             "were not in valid YAML.") from http_error
-            raise
+                                             f"were not in valid YAML."
+                                             f"Error: {http_error.response.text}") from http_error
+            raise requests.exceptions.HTTPError(f"{http_error}."
+                                         f"Error: {http_error.response.text}",
+                                         response=http_error.response) from http_error

--- a/test/test_integration_policy.py
+++ b/test/test_integration_policy.py
@@ -117,6 +117,31 @@ class CliIntegrationPolicy(IntegrationTestCaseBase):  # pragma: no cover
                   str(mock_log.output))
 
     @integration_test()
+    def test_policy_bad_syntax_error_user_recieve_detailed_error(self):
+        policy_with_bad_syntax = "- ! user bad syntax"
+        with redirect_stderr(self.capture_stream):
+            output = utils.load_policy_from_string(self, policy_with_bad_syntax, exit_code=1)
+        self.assertIn("{\"error\":{\"code\":\"validation_failed\",\"message\":", output, 
+                        "Could not find detailed error in the output."
+                        "Expected to find:"
+                        "{\"error\":{\"code\":\"validation_failed\",\"message\":"
+                        "Result:"
+                        f"{output}")
+
+    @integration_test()
+    def test_policy_load_bad_branch_recieve_detailed_error(self):
+        with redirect_stderr(self.capture_stream):
+            output = self.invoke_cli(self.cli_auth_params,
+                           ['policy', 'load', '-b', 'wrong-branch', '-f', 
+                           self.environment.path_provider.get_policy_path("resource")], exit_code=1)
+        self.assertIn("{\"error\":{\"code\":\"not_found\",\"message\":", output, 
+                        "Could not find detailed error in the output."
+                        "Expected to find:"
+                        "{\"error\":{\"code\":\"not_found\",\"message\":"
+                        "Result:"
+                        f"{output}")
+
+    @integration_test()
     def test_policy_replace_load_combo_returns_help_screen(self):
         with redirect_stderr(self.capture_stream):
             output = self.invoke_cli(self.cli_auth_params,


### PR DESCRIPTION
### Desired Outcome

When failing in load policy we'll print the exact error send from the server.

### Implemented Changes

On raising error we'll check the http error response text in addition to the error itself.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

[ONYX-12413](https://ca-il-jira.il.cyber-ark.com:8443/secure/RapidBoard.jspa?rapidView=1475&view=detail&selectedIssue=ONYX-12413)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
