### PR TITLE
CLI UX improvement

### DIFF
--- a/conjur/argument_parser/_login_parser.py
+++ b/conjur/argument_parser/_login_parser.py
@@ -33,16 +33,19 @@ class LoginParser:
                         help='Log in to Conjur server',
                         description=command_description(login_name,
                                                         login_usage),
-                        epilog=command_epilog('conjur login \t\t\t\t'
+                        epilog=command_epilog('conjur login \t\t\t\t\t'
                                               'Prompts for the login name and '
                                               'password to log in to Conjur server\n'
-                                              '    conjur login -i admin \t\t\t'
+                                              '    conjur login -i admin \t\t\t\t'
                                               'Prompts for password of the admin user '
                                               'to log in to Conjur server\n'
-                                              '    conjur login -i admin -p Myp@SSw0rds!\t'
+                                              '    conjur login -i admin -p Myp@SSw0rds!\t\t'
                                               "Logs the admin user in to Conjur server and "
                                               "saves the login name and password in either "
-                                              "the system's credential store or netrc"),
+                                              "the system's credential store or netrc\n"
+                                              "    conjur login -i cucumber/host/myapp"
+                                              " -p <API_Key>\t"
+                                              "Logs the myapp host in to Conjur server"),
                         usage=argparse.SUPPRESS,
                         add_help=False,
                         formatter_class=formatter)

--- a/conjur/controller/host_controller.py
+++ b/conjur/controller/host_controller.py
@@ -35,7 +35,7 @@ class HostController():
                             identifier=self.host_resource_data.host_to_update)
         new_api_key = self.client.rotate_other_api_key(resource)
         # pylint: disable=line-too-long
-        sys.stdout.write(f"Successfully rotated API key for '{self.host_resource_data.host_to_update}' "
+        sys.stdout.write(f"Successfully rotated API key for '{self.host_resource_data.host_to_update}'""\n"
                          f"New API key is: {new_api_key}\n")
 
     def prompt_for_host_id_if_needed(self):

--- a/conjur/controller/user_controller.py
+++ b/conjur/controller/user_controller.py
@@ -35,7 +35,7 @@ class UserController():
         try:
             # pylint: disable=line-too-long
             resource_to_update, new_api_key = self.user_logic.rotate_api_key(self.user_input_data.user_id)
-            sys.stdout.write(f"Successfully rotated API key for '{resource_to_update}'. "
+            sys.stdout.write(f"Successfully rotated API key for '{resource_to_update}'."'\n'
                              f"New API key is: {new_api_key}\n")
         except OperationNotCompletedException:
             sys.stdout.write("An error occurred. Log in again or try again in debug mode.\n")


### PR DESCRIPTION
### Desired Outcome

CLI UX had some small issues we'd like to fix:

1. In the help of login command we need to provide an example for host not just user: conjur login -i cucumber/host/myapp -p <API_Key>
2. The string for API key rotation should be broken down to 2 lines - one for Successfully rotated, and second with the API key.

### Connected Issue/Story

Resolves 

CyberArk internal issue link: [ONYX-13435](https://ca-il-jira.il.cyber-ark.com:8443/secure/RapidBoard.jspa?rapidView=1475&view=detail&selectedIssue=ONYX-13435)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
