### PR TITLE
Make keystore_wrapper.py non static class.

### DIFF
--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -152,7 +152,6 @@ class Client:
         Configures the logging for the client
         """
         # Suppress third party logs
-        KeystoreWrapper.configure_keyring_log_to_info()
 
         if debug:
             logging.basicConfig(level=logging.DEBUG, format=cls.LOGGING_FORMAT)

--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -24,7 +24,6 @@ from conjur.util import util_functions
 from conjur.api import Api
 from conjur.config import Config as ApiConfig
 from conjur.resource import Resource
-from conjur.wrapper import KeystoreWrapper
 
 # pylint: disable=pointless-string-statement
 """

--- a/conjur/logic/credential_provider/credential_store_factory.py
+++ b/conjur/logic/credential_provider/credential_store_factory.py
@@ -30,11 +30,11 @@ class CredentialStoreFactory:
         """
         Factory method for determining which store to use
         """
-        key_store_wrapper = KeystoreWrapper()
-        if key_store_wrapper.get_keyring_name() in SUPPORTED_BACKENDS:
+
+        if KeystoreWrapper.get_keyring_name() in SUPPORTED_BACKENDS:
             # If the keyring is unlocked then we will use it
-            if key_store_wrapper.is_keyring_accessible():
+            if KeystoreWrapper.is_keyring_accessible():
                 # pylint: disable=line-too-long
-                return KeystoreCredentialsProvider(), f'{key_store_wrapper.get_keyring_name()} credential store'
+                return KeystoreCredentialsProvider(), f'{KeystoreWrapper.get_keyring_name()} credential store'
 
         return FileCredentialsProvider(), DEFAULT_NETRC_FILE

--- a/conjur/logic/credential_provider/credential_store_factory.py
+++ b/conjur/logic/credential_provider/credential_store_factory.py
@@ -16,6 +16,7 @@ from conjur.logic.credential_provider.keystore_credentials_provider \
     import KeystoreCredentialsProvider
 from conjur.wrapper import KeystoreWrapper
 
+
 # pylint: disable=too-few-public-methods
 class CredentialStoreFactory:
     """
@@ -23,15 +24,17 @@ class CredentialStoreFactory:
 
     This class follows the Factory pattern to determine which credential store to choose
     """
+
     @classmethod
     def create_credential_store(cls) -> Tuple[CredentialsStoreInterface, str]:
         """
         Factory method for determining which store to use
         """
-        if KeystoreWrapper.get_keyring_name() in SUPPORTED_BACKENDS:
+        key_store_wrapper = KeystoreWrapper()
+        if key_store_wrapper.get_keyring_name() in SUPPORTED_BACKENDS:
             # If the keyring is unlocked then we will use it
-            if KeystoreWrapper.is_keyring_accessible():
+            if key_store_wrapper.is_keyring_accessible():
                 # pylint: disable=line-too-long
-                return KeystoreCredentialsProvider(), f'{KeystoreWrapper.get_keyring_name()} credential store'
+                return KeystoreCredentialsProvider(), f'{key_store_wrapper.get_keyring_name()} credential store'
 
         return FileCredentialsProvider(), DEFAULT_NETRC_FILE

--- a/conjur/logic/credential_provider/keystore_credentials_provider.py
+++ b/conjur/logic/credential_provider/keystore_credentials_provider.py
@@ -20,6 +20,7 @@ from conjur.interface.credentials_store_interface import CredentialsStoreInterfa
 from conjur.wrapper import KeystoreWrapper
 from conjur.data_object.conjurrc_data import ConjurrcData
 
+
 # pylint: disable=logging-fstring-interpolation
 class KeystoreCredentialsProvider(CredentialsStoreInterface):
     """
@@ -29,8 +30,8 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
     in the system's keystore
     """
 
-    def __init__(self): # pragma: no cover
-        pass
+    def __init__(self):  # pragma: no cover
+        self.key_store_wrapper = KeystoreWrapper()
 
     # pylint: disable=line-too-long,logging-fstring-interpolation
     def save(self, credential_data: CredentialsData):
@@ -38,17 +39,19 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
         Method for saving user credentials in the system's keyring
         """
         logging.debug("Attempting to save credentials to the system's credential store "
-                      f"'{KeystoreWrapper.get_keyring_name()}'...")
+                      f"'{self.key_store_wrapper.get_keyring_name()}'...")
         credential_id = credential_data.machine
         try:
-            KeystoreWrapper.set_password(credential_id, MACHINE, credential_data.machine)
-            KeystoreWrapper.set_password(credential_id, LOGIN, credential_data.login)
-            KeystoreWrapper.set_password(credential_id, PASSWORD, credential_data.password)
-            logging.debug(f"Credentials saved to the '{KeystoreWrapper.get_keyring_name()}' credential store")
+            self.key_store_wrapper.set_password(credential_id, MACHINE, credential_data.machine)
+            self.key_store_wrapper.set_password(credential_id, LOGIN, credential_data.login)
+            self.key_store_wrapper.set_password(credential_id, PASSWORD, credential_data.password)
+            logging.debug(
+                f"Credentials saved to the '{self.key_store_wrapper.get_keyring_name()}'"
+                f" credential store")
         except Exception as incomplete_operation:
             raise OperationNotCompletedException(incomplete_operation) from incomplete_operation
 
-    def load(self, conjurrc_conjur_url:str) -> CredentialsData:
+    def load(self, conjurrc_conjur_url: str) -> CredentialsData:
         """
         Method for fetching user credentials from the system's keyring
         """
@@ -57,58 +60,62 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
             raise CredentialRetrievalException
 
         for attr in KEYSTORE_ATTRIBUTES:
-            loaded_credentials[attr] = KeystoreWrapper.get_password(conjurrc_conjur_url, attr)
+            loaded_credentials[attr] = self.key_store_wrapper.get_password(conjurrc_conjur_url,
+                                                                           attr)
         return CredentialsData.convert_dict_to_obj(loaded_credentials)
 
     def is_exists(self, conjurrc_conjur_url) -> bool:
         for attr in KEYSTORE_ATTRIBUTES:
-            if KeystoreWrapper.get_password(conjurrc_conjur_url, attr) is None:
+            if self.key_store_wrapper.get_password(conjurrc_conjur_url, attr) is None:
                 return False
         return True
 
-    def update_api_key_entry(self, user_to_update:str, credential_data:CredentialsData, new_api_key:str):
+    def update_api_key_entry(self, user_to_update: str, credential_data: CredentialsData,
+                             new_api_key: str):
         """
         Method for updating user credentials in the system's keyring
         """
         try:
-            KeystoreWrapper.set_password(credential_data.machine, MACHINE, credential_data.machine)
-            KeystoreWrapper.set_password(credential_data.machine, LOGIN, user_to_update)
-            KeystoreWrapper.set_password(credential_data.machine, PASSWORD, new_api_key)
+            self.key_store_wrapper.set_password(credential_data.machine, MACHINE,
+                                                credential_data.machine)
+            self.key_store_wrapper.set_password(credential_data.machine, LOGIN, user_to_update)
+            self.key_store_wrapper.set_password(credential_data.machine, PASSWORD, new_api_key)
         except Exception as incomplete_operation:
             raise OperationNotCompletedException(incomplete_operation) from incomplete_operation
 
     # pylint: disable=logging-fstring-interpolation,line-too-long
-    def remove_credentials(self, conjurrc:ConjurrcData):
+    def remove_credentials(self, conjurrc: ConjurrcData):
         """
         Method for removing user credentials in the system's keyring
         """
         logging.debug("Attempting to remove credentials from "
-                      f"the '{KeystoreWrapper.get_keyring_name()}' credential store...")
+                      f"the '{self.key_store_wrapper.get_keyring_name()}' credential store...")
         for attr in KEYSTORE_ATTRIBUTES:
             try:
-                KeystoreWrapper.delete_password(conjurrc.conjur_url, attr)
+                self.key_store_wrapper.delete_password(conjurrc.conjur_url, attr)
             # Catches when credentials do not exist in the keyring. If the key does not exist,
             # the user has already logged out. we still try to remove other leftovers
             except KeyringWrapperDeletionError:
                 logging.debug(
-                    f"Unable to delete key '{attr}' from the '{KeystoreWrapper.get_keyring_name()}' "
+                    f"Unable to delete key '{attr}' from the '{self.key_store_wrapper.get_keyring_name()}' "
                     f"credential store. Key may not exist.\n{traceback.format_exc()}")
 
         logging.debug("Successfully removed credentials from the "
-                      f"'{KeystoreWrapper.get_keyring_name()}' credential store")
+                      f"'{self.key_store_wrapper.get_keyring_name()}' credential store")
 
-    def cleanup_if_exists(self, conjurrc_conjur_url:str):
+    def cleanup_if_exists(self, conjurrc_conjur_url: str):
         """
         For each credential attribute, check if exists for
         the conjurrc_conjur_url identifier and delete if exists
         """
         for attr in KEYSTORE_ATTRIBUTES:
             try:
-                if KeystoreWrapper.get_password(conjurrc_conjur_url, attr) is not None:
-                    KeystoreWrapper.delete_password(conjurrc_conjur_url, attr)
+                if self.key_store_wrapper.get_password(conjurrc_conjur_url, attr) is not None:
+                    self.key_store_wrapper.delete_password(conjurrc_conjur_url, attr)
             # Catches when credentials do not exist in the keyring. If the key does not exist,
             # the user has already logged out. we still try to remove other leftovers
             except Exception:  # pylint: disable=broad-except
                 logging.debug(
-                    f"Cleanup failed for key '{attr}' from the '{KeystoreWrapper.get_keyring_name()}' "
+                    f"Cleanup failed for key '{attr}' from the '"
+                    f"{self.key_store_wrapper.get_keyring_name()}' "
                     f"credential store.\n{traceback.format_exc()}")

--- a/conjur/logic/credential_provider/keystore_credentials_provider.py
+++ b/conjur/logic/credential_provider/keystore_credentials_provider.py
@@ -31,7 +31,7 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
     """
 
     def __init__(self):  # pragma: no cover
-        self.key_store_wrapper = KeystoreWrapper()
+        pass
 
     # pylint: disable=line-too-long,logging-fstring-interpolation
     def save(self, credential_data: CredentialsData):
@@ -39,14 +39,14 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
         Method for saving user credentials in the system's keyring
         """
         logging.debug("Attempting to save credentials to the system's credential store "
-                      f"'{self.key_store_wrapper.get_keyring_name()}'...")
+                      f"'{KeystoreWrapper.get_keyring_name()}'...")
         credential_id = credential_data.machine
         try:
-            self.key_store_wrapper.set_password(credential_id, MACHINE, credential_data.machine)
-            self.key_store_wrapper.set_password(credential_id, LOGIN, credential_data.login)
-            self.key_store_wrapper.set_password(credential_id, PASSWORD, credential_data.password)
+            KeystoreWrapper.set_password(credential_id, MACHINE, credential_data.machine)
+            KeystoreWrapper.set_password(credential_id, LOGIN, credential_data.login)
+            KeystoreWrapper.set_password(credential_id, PASSWORD, credential_data.password)
             logging.debug(
-                f"Credentials saved to the '{self.key_store_wrapper.get_keyring_name()}'"
+                f"Credentials saved to the '{KeystoreWrapper.get_keyring_name()}'"
                 f" credential store")
         except Exception as incomplete_operation:
             raise OperationNotCompletedException(incomplete_operation) from incomplete_operation
@@ -60,13 +60,13 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
             raise CredentialRetrievalException
 
         for attr in KEYSTORE_ATTRIBUTES:
-            loaded_credentials[attr] = self.key_store_wrapper.get_password(conjurrc_conjur_url,
+            loaded_credentials[attr] = KeystoreWrapper.get_password(conjurrc_conjur_url,
                                                                            attr)
         return CredentialsData.convert_dict_to_obj(loaded_credentials)
 
     def is_exists(self, conjurrc_conjur_url) -> bool:
         for attr in KEYSTORE_ATTRIBUTES:
-            if self.key_store_wrapper.get_password(conjurrc_conjur_url, attr) is None:
+            if KeystoreWrapper.get_password(conjurrc_conjur_url, attr) is None:
                 return False
         return True
 
@@ -76,10 +76,10 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
         Method for updating user credentials in the system's keyring
         """
         try:
-            self.key_store_wrapper.set_password(credential_data.machine, MACHINE,
+            KeystoreWrapper.set_password(credential_data.machine, MACHINE,
                                                 credential_data.machine)
-            self.key_store_wrapper.set_password(credential_data.machine, LOGIN, user_to_update)
-            self.key_store_wrapper.set_password(credential_data.machine, PASSWORD, new_api_key)
+            KeystoreWrapper.set_password(credential_data.machine, LOGIN, user_to_update)
+            KeystoreWrapper.set_password(credential_data.machine, PASSWORD, new_api_key)
         except Exception as incomplete_operation:
             raise OperationNotCompletedException(incomplete_operation) from incomplete_operation
 
@@ -89,19 +89,19 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
         Method for removing user credentials in the system's keyring
         """
         logging.debug("Attempting to remove credentials from "
-                      f"the '{self.key_store_wrapper.get_keyring_name()}' credential store...")
+                      f"the '{KeystoreWrapper.get_keyring_name()}' credential store...")
         for attr in KEYSTORE_ATTRIBUTES:
             try:
-                self.key_store_wrapper.delete_password(conjurrc.conjur_url, attr)
+                KeystoreWrapper.delete_password(conjurrc.conjur_url, attr)
             # Catches when credentials do not exist in the keyring. If the key does not exist,
             # the user has already logged out. we still try to remove other leftovers
             except KeyringWrapperDeletionError:
                 logging.debug(
-                    f"Unable to delete key '{attr}' from the '{self.key_store_wrapper.get_keyring_name()}' "
+                    f"Unable to delete key '{attr}' from the '{KeystoreWrapper.get_keyring_name()}' "
                     f"credential store. Key may not exist.\n{traceback.format_exc()}")
 
         logging.debug("Successfully removed credentials from the "
-                      f"'{self.key_store_wrapper.get_keyring_name()}' credential store")
+                      f"'{KeystoreWrapper.get_keyring_name()}' credential store")
 
     def cleanup_if_exists(self, conjurrc_conjur_url: str):
         """
@@ -110,12 +110,12 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
         """
         for attr in KEYSTORE_ATTRIBUTES:
             try:
-                if self.key_store_wrapper.get_password(conjurrc_conjur_url, attr) is not None:
-                    self.key_store_wrapper.delete_password(conjurrc_conjur_url, attr)
+                if KeystoreWrapper.get_password(conjurrc_conjur_url, attr) is not None:
+                    KeystoreWrapper.delete_password(conjurrc_conjur_url, attr)
             # Catches when credentials do not exist in the keyring. If the key does not exist,
             # the user has already logged out. we still try to remove other leftovers
             except Exception:  # pylint: disable=broad-except
                 logging.debug(
                     f"Cleanup failed for key '{attr}' from the '"
-                    f"{self.key_store_wrapper.get_keyring_name()}' "
+                    f"{KeystoreWrapper.get_keyring_name()}' "
                     f"credential store.\n{traceback.format_exc()}")

--- a/conjur/util/design_patterns_base_classes/singelton.py
+++ b/conjur/util/design_patterns_base_classes/singelton.py
@@ -8,9 +8,16 @@ Represent a base class implement singleton design pattern
 
 
 class Singleton(type):
+    """
+    Base class that make sure an inherit class is a singleton
+    Should be used like this 'class A(metaclass=Singleton)'
+    """
     _instances = {}
 
     def __call__(cls, *args, **kwargs):
+        """
+        override the __call__ function (). return an instance if already exist
+        """
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]

--- a/conjur/util/singelton.py
+++ b/conjur/util/singelton.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""
+singleton module
+
+Represent a base class implement singleton design pattern
+"""
+
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/conjur/wrapper/keystore_wrapper.py
+++ b/conjur/wrapper/keystore_wrapper.py
@@ -16,13 +16,14 @@ from typing import Optional
 import keyring
 
 # Internals
-from conjur.errors import KeyringWrapperDeletionError, KeyringWrapperGeneralError\
+from conjur.errors import KeyringWrapperDeletionError, KeyringWrapperGeneralError \
     , KeyringWrapperSetError
 from conjur.util.util_functions import configure_env_var_with_keyring
 
 # Function is called in the module so that before accessing the
 # system’s keyring, the environment will be configured correctly
 configure_env_var_with_keyring()
+
 
 class KeystoreWrapper:
     """
@@ -31,8 +32,10 @@ class KeystoreWrapper:
     A class for wrapping used functionality from the keyring library
     """
 
-    @classmethod
-    def set_password(cls, identifier:str, key:str, val:str):
+    def __init__(self):
+        logging.getLogger('keyring').setLevel(logging.INFO)
+
+    def set_password(self, identifier: str, key: str, val: str):
         """
         Method for setting a password in keyring
         """
@@ -46,8 +49,7 @@ class KeystoreWrapper:
                                                      f"(Failed to set '{key}')'") from exception
 
     # pylint: disable=try-except-raise
-    @classmethod
-    def get_password(cls, identifier:str, key:str):
+    def get_password(self, identifier: str, key: str):
         """
         Method for getting a password in keyring
         """
@@ -58,8 +60,7 @@ class KeystoreWrapper:
                                                      f"(Failed to get '{key}')'") from exception
 
     # pylint: disable=try-except-raise
-    @classmethod
-    def delete_password(cls, identifier:str, key:str):
+    def delete_password(self, identifier: str, key: str):
         """
         Method for deleting a password in keyring
         """
@@ -71,8 +72,8 @@ class KeystoreWrapper:
         except Exception as exception:
             raise KeyringWrapperGeneralError(message=f"General keyring error has occurred "
                                                      f"(Failed to delete '{key}')'") from exception
-    @classmethod
-    def get_keyring_name(cls) -> Optional[str]:
+
+    def get_keyring_name(self) -> Optional[str]:
         """
         Method to get the system's keyring name
         """
@@ -86,8 +87,7 @@ class KeystoreWrapper:
             logging.debug(err)
             return None
 
-    @classmethod
-    def is_keyring_accessible(cls) -> bool:
+    def is_keyring_accessible(self) -> bool:
         """
         Method to check if the keyring is accessible
         """
@@ -105,10 +105,3 @@ class KeystoreWrapper:
             return False
 
         return True
-
-    @classmethod
-    def configure_keyring_log_to_info(cls):
-        """
-        Method to configure the keyring logs to info
-        """
-        logging.getLogger('keyring').setLevel(logging.INFO)

--- a/conjur/wrapper/keystore_wrapper.py
+++ b/conjur/wrapper/keystore_wrapper.py
@@ -19,13 +19,14 @@ import keyring
 from conjur.errors import KeyringWrapperDeletionError, KeyringWrapperGeneralError \
     , KeyringWrapperSetError
 from conjur.util.util_functions import configure_env_var_with_keyring
+from conjur.util.singelton import Singleton
 
 # Function is called in the module so that before accessing the
 # system’s keyring, the environment will be configured correctly
 configure_env_var_with_keyring()
 
 
-class KeystoreWrapper:
+class KeystoreWrapper(metaclass=Singleton):
     """
     KeystoreWrapper
 
@@ -105,3 +106,8 @@ class KeystoreWrapper:
             return False
 
         return True
+
+
+if __name__ == '__main__':
+    KeystoreWrapper()
+    KeystoreWrapper()

--- a/conjur/wrapper/keystore_wrapper.py
+++ b/conjur/wrapper/keystore_wrapper.py
@@ -19,24 +19,35 @@ import keyring
 from conjur.errors import KeyringWrapperDeletionError, KeyringWrapperGeneralError \
     , KeyringWrapperSetError
 from conjur.util.util_functions import configure_env_var_with_keyring
-from conjur.util.singelton import Singleton
 
 # Function is called in the module so that before accessing the
 # system’s keyring, the environment will be configured correctly
 configure_env_var_with_keyring()
 
 
-class KeystoreWrapper(metaclass=Singleton):
+def validate_log_level(func):
+    """
+    Method decorator that make sure no sensitive log is written
+    """
+
+    def inner(*args, **kwargs):
+        if logging.getLogger("keyring").level <= logging.INFO:
+            logging.getLogger("keyring").setLevel(logging.INFO)
+        return func(*args, **kwargs)
+
+    return inner
+
+
+class KeystoreWrapper:
     """
     KeystoreWrapper
 
     A class for wrapping used functionality from the keyring library
     """
 
-    def __init__(self):
-        logging.getLogger('keyring').setLevel(logging.INFO)
-
-    def set_password(self, identifier: str, key: str, val: str):
+    @staticmethod
+    @validate_log_level
+    def set_password(identifier: str, key: str, val: str):
         """
         Method for setting a password in keyring
         """
@@ -50,7 +61,9 @@ class KeystoreWrapper(metaclass=Singleton):
                                                      f"(Failed to set '{key}')'") from exception
 
     # pylint: disable=try-except-raise
-    def get_password(self, identifier: str, key: str):
+    @staticmethod
+    @validate_log_level
+    def get_password(identifier: str, key: str):
         """
         Method for getting a password in keyring
         """
@@ -61,7 +74,9 @@ class KeystoreWrapper(metaclass=Singleton):
                                                      f"(Failed to get '{key}')'") from exception
 
     # pylint: disable=try-except-raise
-    def delete_password(self, identifier: str, key: str):
+    @staticmethod
+    @validate_log_level
+    def delete_password(identifier: str, key: str):
         """
         Method for deleting a password in keyring
         """
@@ -74,7 +89,9 @@ class KeystoreWrapper(metaclass=Singleton):
             raise KeyringWrapperGeneralError(message=f"General keyring error has occurred "
                                                      f"(Failed to delete '{key}')'") from exception
 
-    def get_keyring_name(self) -> Optional[str]:
+    @staticmethod
+    @validate_log_level
+    def get_keyring_name() -> Optional[str]:
         """
         Method to get the system's keyring name
         """
@@ -88,7 +105,9 @@ class KeystoreWrapper(metaclass=Singleton):
             logging.debug(err)
             return None
 
-    def is_keyring_accessible(self) -> bool:
+    @staticmethod
+    @validate_log_level
+    def is_keyring_accessible() -> bool:
         """
         Method to check if the keyring is accessible
         """
@@ -106,8 +125,3 @@ class KeystoreWrapper(metaclass=Singleton):
             return False
 
         return True
-
-
-if __name__ == '__main__':
-    KeystoreWrapper()
-    KeystoreWrapper()

--- a/test/test_unit_keystore_adapter.py
+++ b/test/test_unit_keystore_adapter.py
@@ -1,7 +1,7 @@
 # Builtin
-import importlib
 import unittest
 from unittest.mock import patch
+import logging
 
 # Third-Party
 import keyring
@@ -16,30 +16,48 @@ from conjur.wrapper import KeystoreWrapper
 class KeystoreWrapperTest(unittest.TestCase):
     @patch.object(keyring, "delete_password")
     def test_delete_password_calls_keyring_delete_password(self, mock_keyring):
-        KeystoreWrapper().delete_password(TEST_HOSTNAME, "key")
+        KeystoreWrapper.delete_password(TEST_HOSTNAME, "key")
         mock_keyring.assert_called_once_with(TEST_HOSTNAME, "key")
 
     @patch.object(keyring, "delete_password", side_effect=keyring.errors.KeyringError)
     def test_delete_password_raises_keyring_error(self, mock_delete_password):
         with self.assertRaises(KeyringWrapperGeneralError):
-            KeystoreWrapper().delete_password(TEST_HOSTNAME, "some_key")
+            KeystoreWrapper.delete_password(TEST_HOSTNAME, "some_key")
 
     @patch.object(keyring, "delete_password", side_effect=keyring.errors.PasswordDeleteError)
     def test_delete_password_raises_expected_exceptions(self, mock_delete_password):
         with self.assertRaises(KeyringWrapperDeletionError):
-            KeystoreWrapper().delete_password(TEST_HOSTNAME, "some_key")
+            KeystoreWrapper.delete_password(TEST_HOSTNAME, "some_key")
 
     @patch.object(keyring, "get_password", return_value=None)
     def test_is_keyring_accessible_return_true_when_get_password(self, mock_keyring):
-        keyring_accessible = KeystoreWrapper().is_keyring_accessible()
+        keyring_accessible = KeystoreWrapper.is_keyring_accessible()
         mock_keyring.assert_called_once_with('test-system', 'test-accessibility')
         self.assertEquals(True, keyring_accessible)
 
     @patch.object(keyring, "get_password", side_effect=keyring.errors.KeyringError)
     def test_is_keyring_accessible_returns_false_on_keyring_error(self, mock_keyring):
-        self.assertEquals(False, KeystoreWrapper().is_keyring_accessible())
+        self.assertEquals(False, KeystoreWrapper.is_keyring_accessible())
 
-    def test_wrapper_is_singelton(self):
-        wrapper = KeystoreWrapper()
-        object_id = id(wrapper)
-        self.assertEquals(object_id, id(KeystoreWrapper()))
+    def test_get_keyring_name_use_proper_log_level(self):
+        logging.getLogger('keyring').setLevel(logging.DEBUG)
+        KeystoreWrapper.get_keyring_name()
+        self.assertEquals(logging.getLogger('keyring').level, logging.INFO)
+
+    @patch.object(keyring, "get_password", return_value=None)
+    def test_get_password_use_proper_log_level(self, mock):
+        logging.getLogger('keyring').setLevel(logging.DEBUG)
+        KeystoreWrapper.get_password("", "")
+        self.assertEquals(logging.getLogger('keyring').level, logging.INFO)
+
+    @patch.object(keyring, "delete_password", return_value=None)
+    def test_get_delete_password_use_proper_log_level(self, mock):
+        logging.getLogger('keyring').setLevel(logging.DEBUG)
+        KeystoreWrapper.delete_password("", "")
+        self.assertEquals(logging.getLogger('keyring').level, logging.INFO)
+
+    @patch.object(keyring, "set_password", return_value=None)
+    def test_get_set_password_use_proper_log_level(self, mock):
+        logging.getLogger('keyring').setLevel(logging.DEBUG)
+        KeystoreWrapper.set_password("", "", "")
+        self.assertEquals(logging.getLogger('keyring').level, logging.INFO)

--- a/test/test_unit_keystore_adapter.py
+++ b/test/test_unit_keystore_adapter.py
@@ -16,25 +16,25 @@ from conjur.wrapper import KeystoreWrapper
 class KeystoreWrapperTest(unittest.TestCase):
     @patch.object(keyring, "delete_password")
     def test_delete_password_calls_keyring_delete_password(self, mock_keyring):
-        KeystoreWrapper.delete_password(TEST_HOSTNAME, "key")
+        KeystoreWrapper().delete_password(TEST_HOSTNAME, "key")
         mock_keyring.assert_called_once_with(TEST_HOSTNAME, "key")
 
     @patch.object(keyring, "delete_password", side_effect=keyring.errors.KeyringError)
     def test_delete_password_raises_keyring_error(self, mock_delete_password):
         with self.assertRaises(KeyringWrapperGeneralError):
-            KeystoreWrapper.delete_password(TEST_HOSTNAME, "some_key")
+            KeystoreWrapper().delete_password(TEST_HOSTNAME, "some_key")
 
     @patch.object(keyring, "delete_password", side_effect=keyring.errors.PasswordDeleteError)
     def test_delete_password_raises_expected_exceptions(self, mock_delete_password):
         with self.assertRaises(KeyringWrapperDeletionError):
-            KeystoreWrapper.delete_password(TEST_HOSTNAME, "some_key")
+            KeystoreWrapper().delete_password(TEST_HOSTNAME, "some_key")
 
     @patch.object(keyring, "get_password", return_value=None)
     def test_is_keyring_accessible_return_true_when_get_password(self, mock_keyring):
-        keyring_accessible = KeystoreWrapper.is_keyring_accessible()
+        keyring_accessible = KeystoreWrapper().is_keyring_accessible()
         mock_keyring.assert_called_once_with('test-system', 'test-accessibility')
         self.assertEquals(True, keyring_accessible)
 
     @patch.object(keyring, "get_password", side_effect=keyring.errors.KeyringError)
     def test_is_keyring_accessible_returns_false_on_keyring_error(self, mock_keyring):
-        self.assertEquals(False, KeystoreWrapper.is_keyring_accessible())
+        self.assertEquals(False, KeystoreWrapper().is_keyring_accessible())

--- a/test/test_unit_keystore_adapter.py
+++ b/test/test_unit_keystore_adapter.py
@@ -38,3 +38,8 @@ class KeystoreWrapperTest(unittest.TestCase):
     @patch.object(keyring, "get_password", side_effect=keyring.errors.KeyringError)
     def test_is_keyring_accessible_returns_false_on_keyring_error(self, mock_keyring):
         self.assertEquals(False, KeystoreWrapper().is_keyring_accessible())
+
+    def test_wrapper_is_singelton(self):
+        wrapper = KeystoreWrapper()
+        object_id = id(wrapper)
+        self.assertEquals(object_id, id(KeystoreWrapper()))

--- a/test/util/test_path_provider.py
+++ b/test/util/test_path_provider.py
@@ -15,23 +15,8 @@ class TestRunnerPathProvider(metaclass=Singleton):  # pragma: no cover
     the constants module to be more stable. we use abstract
     class so that every enviornment could easily setup it's own files structure.
     """
-    __instance = None
-
-    @staticmethod
-    def getInstance():
-        """
-        Implement the singelton design pattern. so we will be sure all path's are stable
-        @return:  TestPathProvider
-        """
-        if TestRunnerPathProvider.__instance is None:
-            TestRunnerPathProvider()
-        return TestRunnerPathProvider.__instance
 
     def __init__(self, root_dir=None, file_helper_dir=None):
-        if TestRunnerPathProvider.__instance is not None:
-            raise Exception("This class is a singleton!")
-        else:
-            TestRunnerPathProvider.__instance = self
 
         if root_dir:
             self.ROOT_DIR = root_dir

--- a/test/util/test_path_provider.py
+++ b/test/util/test_path_provider.py
@@ -2,9 +2,10 @@ from pathlib import Path
 
 # Internals
 from conjur.constants import *
+from conjur.util.design_patterns_base_classes.singelton import Singleton
 
 
-class TestRunnerPathProvider():  # pragma: no cover
+class TestRunnerPathProvider(metaclass=Singleton):  # pragma: no cover
     """
     used to generate the files path's in all tests
     in particular this file is helping with the

--- a/test/util/test_runners/integrations_tests_runner.py
+++ b/test/util/test_runners/integrations_tests_runner.py
@@ -39,6 +39,8 @@ import uuid
 import ssl
 
 # Internals
+# here for packing reason
+from conjur.util.design_patterns_base_classes.singelton import Singleton
 from test.test_integration_policy import CliIntegrationPolicy
 from test.test_integration_variable import CliIntegrationTestVariable
 from test.test_integration_configurations import CliIntegrationTestConfigurations

--- a/test/util/test_runners/params.py
+++ b/test/util/test_runners/params.py
@@ -9,7 +9,9 @@ class ClientParams:
     Default params are used for test_integration script
     """
 
-    def __init__(self, url=os.environ.get('TEST_HOSTNAME') or 'https://conjur-https', account='dev', login='admin', api_key=None):
+    def __init__(
+            self, url=os.environ.get('TEST_HOSTNAME') or 'https://conjur-https', account='dev',
+            login='admin', api_key=None):
         self.hostname = url
         self.account = account
         self.login = login
@@ -24,13 +26,12 @@ class TestEnvironmentParams:
     Default params are used for test_integration script
     """
 
-    def __init__(self, cli_to_test=None, invoke_process=False,
-                 path_provider=None):
+    def __init__(
+            self, cli_to_test=None, invoke_process=False,
+            path_provider=None):
         self.invoke_process = invoke_process
         self.cli_to_test = cli_to_test
         if path_provider:
             self.path_provider = path_provider
-        elif TestRunnerPathProvider.getInstance():
-            self.path_provider = TestRunnerPathProvider.getInstance()
         else:
             self.path_provider = TestRunnerPathProvider()


### PR DESCRIPTION


### Desired Outcome

keyStoreWrapper is now must be initialized in order to use.
Motivation is
- Disable logging on creation (more safe since logging could hold sensitive data)
- Part of the client refactor done in [ONYX-14370](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14370)

### Implemented Changes

- Make keyStoreWrapper a not static class

### Connected Issue/Story

[ONYX-14370](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14370)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
