### PR TITLE
Credential_store_factory.py now return store only.

### DIFF
--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -132,7 +132,8 @@ class Client:
                             **loaded_config)
             self._api.login(login_id, password)
         else:
-            credential_provider, credential_location = CredentialStoreFactory.create_credential_store()
+            credential_provider = CredentialStoreFactory.create_credential_store()
+            credential_location = credential_provider.get_store_location()
             logging.debug(f"Attempting to retrieve credentials from the '{credential_location}'...")
             loaded_credentials = credential_provider.load(loaded_config['url'])
             logging.debug(f"Successfully retrieved credentials from the '{credential_location}'")

--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -52,17 +52,19 @@ class Client:
 
     # The method signature is long but we want to explicitly control
     # what parameters are allowed
-    # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,line-too-long,try-except-raise,too-many-statements
-    def __init__(self,
-                 account: str = None,
-                 api_key: str = None,
-                 ca_bundle: str = None,
-                 debug: bool = False,
-                 http_debug=False,
-                 login_id: str = None,
-                 password: str = None,
-                 ssl_verify: bool = True,
-                 url: str = None):
+    # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,line-too-long,
+    # try-except-raise,too-many-statements
+    def __init__(
+            self,
+            account: str = None,
+            api_key: str = None,
+            ca_bundle: str = None,
+            debug: bool = False,
+            http_debug=False,
+            login_id: str = None,
+            password: str = None,
+            ssl_verify: bool = True,
+            url: str = None):
 
         if ssl_verify is False:
             util_functions.get_insecure_warning_in_debug()
@@ -104,14 +106,17 @@ class Client:
                 raise CertificateVerificationException(
                     cause="The client was initialized without certificate verification, "
                           "even though the command was ran with certificate verification enabled.",
-                    solution="To continue communicating with the server insecurely, run the command "
-                             "again with ssl_verify = False. Otherwise, reinitialize the client.") from cert_verify
+                    solution="To continue communicating with the server insecurely, "
+                             "run the command "
+                             "again with ssl_verify = False. Otherwise, reinitialize the "
+                             "client.") from cert_verify
             except ConfigurationMissingException as missing_config_exec:
                 raise ConfigurationMissingException from missing_config_exec
             except InvalidConfigurationException as invalid_config_exec:
                 raise InvalidConfigurationException from invalid_config_exec
-            except Exception:
-                raise
+            # pylint: disable =try-except-raise
+            except Exception as error:
+                raise error
 
         # We only want to override missing account info with "default"
         # if we can't find it anywhere else.
@@ -252,8 +257,9 @@ class Client:
         """
         return self._api.rotate_personal_api_key(logged_in_user, current_password)
 
-    def change_personal_password(self, logged_in_user: str, current_password: str,
-                                 new_password: str) -> str:
+    def change_personal_password(
+            self, logged_in_user: str, current_password: str,
+            new_password: str) -> str:
         """
         Change personal password of logged-in user
         """

--- a/conjur/cli.py
+++ b/conjur/cli.py
@@ -44,7 +44,7 @@ class Cli:
         # TODO stop using testing_env
         self.is_testing_env = str(os.getenv('TEST_ENV')).lower() == 'true'
 
-        self.credential_provider, _ = CredentialStoreFactory.create_credential_store()
+        self.credential_provider = CredentialStoreFactory.create_credential_store()
 
     def run(self):
         """

--- a/conjur/interface/credentials_store_interface.py
+++ b/conjur/interface/credentials_store_interface.py
@@ -62,3 +62,10 @@ class CredentialsStoreInterface(metaclass=abc.ABCMeta):  # pragma: no cover
         this function will make sure no leftovers left.
         """
         raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_store_location(self):
+        """
+        Method to return the source of the credentials
+        """
+        raise NotImplementedError()

--- a/conjur/logic/credential_provider/credential_store_factory.py
+++ b/conjur/logic/credential_provider/credential_store_factory.py
@@ -5,11 +5,9 @@ CredentialStoreFactory module
 
 This module is a factory for determining which credential store to use
 """
-# Builtin
-from typing import Tuple
 
 # Internals
-from conjur.constants import SUPPORTED_BACKENDS, DEFAULT_NETRC_FILE
+from conjur.constants import SUPPORTED_BACKENDS
 from conjur.interface.credentials_store_interface import CredentialsStoreInterface
 from conjur.logic.credential_provider.file_credentials_provider import FileCredentialsProvider
 from conjur.logic.credential_provider.keystore_credentials_provider \

--- a/conjur/logic/credential_provider/credential_store_factory.py
+++ b/conjur/logic/credential_provider/credential_store_factory.py
@@ -26,7 +26,7 @@ class CredentialStoreFactory:
     """
 
     @classmethod
-    def create_credential_store(cls) -> Tuple[CredentialsStoreInterface, str]:
+    def create_credential_store(cls) -> CredentialsStoreInterface:
         """
         Factory method for determining which store to use
         """
@@ -34,7 +34,6 @@ class CredentialStoreFactory:
         if keyring_name in SUPPORTED_BACKENDS:
             # If the keyring is unlocked then we will use it
             if KeystoreWrapper.is_keyring_accessible():
-                # pylint: disable=line-too-long
-                return KeystoreCredentialsProvider(), f'{keyring_name} credential store'
+                return KeystoreCredentialsProvider()
 
-        return FileCredentialsProvider(), DEFAULT_NETRC_FILE
+        return FileCredentialsProvider()

--- a/conjur/logic/credential_provider/file_credentials_provider.py
+++ b/conjur/logic/credential_provider/file_credentials_provider.py
@@ -102,7 +102,7 @@ class FileCredentialsProvider(CredentialsStoreInterface):
         """
         Method that removes the described login entry from netrc
         """
-        logging.debug(f"Attempting to remove credentials from '{DEFAULT_NETRC_FILE}'...")
+        logging.debug(f"Attempting to remove credentials from '{self.netrc_path}'...")
         # pylint: disable=no-else-return
         if not os.path.exists(DEFAULT_NETRC_FILE):
             return
@@ -119,7 +119,7 @@ class FileCredentialsProvider(CredentialsStoreInterface):
         else:
             raise NotLoggedInException("You are already logged out.")
 
-        logging.debug(f"Successfully removed credentials from '{DEFAULT_NETRC_FILE}'")
+        logging.debug(f"Successfully removed credentials from '{self.netrc_path}'")
 
     # TODO check if we are using outside of this class. if not make private
     @classmethod

--- a/conjur/logic/credential_provider/file_credentials_provider.py
+++ b/conjur/logic/credential_provider/file_credentials_provider.py
@@ -27,6 +27,7 @@ class FileCredentialsProvider(CredentialsStoreInterface):
 
     This class holds logic when credentials are kept in the netrc
     """
+
     FIRST_TIME_LOG_INSECURE_STORE_WARNING = True  # Static
 
     def __init__(self, netrc_path=DEFAULT_NETRC_FILE):
@@ -180,3 +181,9 @@ class FileCredentialsProvider(CredentialsStoreInterface):
         # This is more relevant for the Keyring scenario than the
         # netrc for now.
         pass
+
+    def get_store_location(self):
+        """
+        Method to return the source of the credentials
+        """
+        return self.netrc_path

--- a/conjur/logic/credential_provider/keystore_credentials_provider.py
+++ b/conjur/logic/credential_provider/keystore_credentials_provider.py
@@ -31,7 +31,7 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
     """
 
     def __init__(self):  # pragma: no cover
-        pass
+        self.keyring_name = KeystoreWrapper.get_keyring_name()
 
     # pylint: disable=line-too-long,logging-fstring-interpolation
     def save(self, credential_data: CredentialsData):
@@ -39,14 +39,14 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
         Method for saving user credentials in the system's keyring
         """
         logging.debug("Attempting to save credentials to the system's credential store "
-                      f"'{KeystoreWrapper.get_keyring_name()}'...")
+                      f"'{self.keyring_name}'...")
         credential_id = credential_data.machine
         try:
             KeystoreWrapper.set_password(credential_id, MACHINE, credential_data.machine)
             KeystoreWrapper.set_password(credential_id, LOGIN, credential_data.login)
             KeystoreWrapper.set_password(credential_id, PASSWORD, credential_data.password)
             logging.debug(
-                f"Credentials saved to the '{KeystoreWrapper.get_keyring_name()}'"
+                f"Credentials saved to the '{self.keyring_name}'"
                 f" credential store")
         except Exception as incomplete_operation:
             raise OperationNotCompletedException(incomplete_operation) from incomplete_operation
@@ -90,7 +90,7 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
         Method for removing user credentials in the system's keyring
         """
         logging.debug("Attempting to remove credentials from "
-                      f"the '{KeystoreWrapper.get_keyring_name()}' credential store...")
+                      f"the '{self.keyring_name}' credential store...")
         for attr in KEYSTORE_ATTRIBUTES:
             try:
                 KeystoreWrapper.delete_password(conjurrc.conjur_url, attr)
@@ -98,12 +98,12 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
             # the user has already logged out. we still try to remove other leftovers
             except KeyringWrapperDeletionError:
                 logging.debug(
-                    f"Unable to delete key '{attr}' from the '"
-                    f"{KeystoreWrapper.get_keyring_name()}' "
-                    f"credential store. Key may not exist.\n{traceback.format_exc()}")
+                    f"Unable to delete key '{attr}' from the "
+                    f"'{self.keyring_name}' credential store. Key may not exist."
+                    f"\n{traceback.format_exc()}")
 
         logging.debug("Successfully removed credentials from the "
-                      f"'{KeystoreWrapper.get_keyring_name()}' credential store")
+                      f"'{self.keyring_name}' credential store")
 
     def cleanup_if_exists(self, conjurrc_conjur_url: str):
         """
@@ -118,12 +118,12 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
             # the user has already logged out. we still try to remove other leftovers
             except Exception:  # pylint: disable=broad-except
                 logging.debug(
-                    f"Cleanup failed for key '{attr}' from the '"
-                    f"{KeystoreWrapper.get_keyring_name()}' "
-                    f"credential store.\n{traceback.format_exc()}")
+                    f"Cleanup failed for key '{attr}' from the "
+                    f"'{self.keyring_name} credential store.' "
+                    f"\n{traceback.format_exc()}")
 
     def get_store_location(self):
         """
         Method to return the source of the credentials
         """
-        return f'{KeystoreWrapper.get_keyring_name()} credential store'
+        return f"{self.keyring_name} credentials store"

--- a/conjur/logic/credential_provider/keystore_credentials_provider.py
+++ b/conjur/logic/credential_provider/keystore_credentials_provider.py
@@ -61,7 +61,7 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
 
         for attr in KEYSTORE_ATTRIBUTES:
             loaded_credentials[attr] = KeystoreWrapper.get_password(conjurrc_conjur_url,
-                                                                           attr)
+                                                                    attr)
         return CredentialsData.convert_dict_to_obj(loaded_credentials)
 
     def is_exists(self, conjurrc_conjur_url) -> bool:
@@ -70,14 +70,15 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
                 return False
         return True
 
-    def update_api_key_entry(self, user_to_update: str, credential_data: CredentialsData,
-                             new_api_key: str):
+    def update_api_key_entry(
+            self, user_to_update: str, credential_data: CredentialsData,
+            new_api_key: str):
         """
         Method for updating user credentials in the system's keyring
         """
         try:
             KeystoreWrapper.set_password(credential_data.machine, MACHINE,
-                                                credential_data.machine)
+                                         credential_data.machine)
             KeystoreWrapper.set_password(credential_data.machine, LOGIN, user_to_update)
             KeystoreWrapper.set_password(credential_data.machine, PASSWORD, new_api_key)
         except Exception as incomplete_operation:
@@ -97,7 +98,8 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
             # the user has already logged out. we still try to remove other leftovers
             except KeyringWrapperDeletionError:
                 logging.debug(
-                    f"Unable to delete key '{attr}' from the '{KeystoreWrapper.get_keyring_name()}' "
+                    f"Unable to delete key '{attr}' from the '"
+                    f"{KeystoreWrapper.get_keyring_name()}' "
                     f"credential store. Key may not exist.\n{traceback.format_exc()}")
 
         logging.debug("Successfully removed credentials from the "
@@ -119,3 +121,9 @@ class KeystoreCredentialsProvider(CredentialsStoreInterface):
                     f"Cleanup failed for key '{attr}' from the '"
                     f"{KeystoreWrapper.get_keyring_name()}' "
                     f"credential store.\n{traceback.format_exc()}")
+
+    def get_store_location(self):
+        """
+        Method to return the source of the credentials
+        """
+        return f'{KeystoreWrapper.get_keyring_name()} credential store'

--- a/test/test_integration_resource.py
+++ b/test/test_integration_resource.py
@@ -63,7 +63,7 @@ class CliIntegrationResourceTest(IntegrationTestCaseBase):  # pragma: no cover
         self.invoke_cli(self.cli_auth_params,
                         ['login', '-i', 'someuser', '-p', extract_api_key_from_message])
 
-        credential_store,_ = CredentialStoreFactory.create_credential_store()
+        credential_store = CredentialStoreFactory.create_credential_store()
         loaded_conjurrc = ConjurrcData.load_from_file()
         old_api_key = credential_store.load(loaded_conjurrc.conjur_url).password
         some_user_api_key = self.invoke_cli(self.cli_auth_params,
@@ -72,7 +72,7 @@ class CliIntegrationResourceTest(IntegrationTestCaseBase):  # pragma: no cover
 
         assert old_api_key != extract_api_key_from_message, "the API keys are the same!"
 
-        credential_store, _ = CredentialStoreFactory.create_credential_store()
+        credential_store = CredentialStoreFactory.create_credential_store()
         new_api_key = credential_store.load(loaded_conjurrc.conjur_url).password
 
         assert new_api_key.strip() == extract_api_key_from_message, "the API keys are not the same!"

--- a/test/test_unit_credential_store_factory.py
+++ b/test/test_unit_credential_store_factory.py
@@ -13,18 +13,18 @@ class CredentialStoreFactoryTest(unittest.TestCase):
     @patch.object(KeystoreWrapper, "is_keyring_accessible", return_value=True)
     def test_create_credential_store_returns_keystore_when_there_is_keyring_and_is_accessible(
             self, mock_keystore_wrapper, mock_another_keystore_wrapper):
-        provider, _ = CredentialStoreFactory.create_credential_store()
+        provider = CredentialStoreFactory.create_credential_store()
         self.assertIsInstance(provider, KeystoreCredentialsProvider)
 
     @patch.object(KeystoreWrapper, "get_keyring_name", return_value=None)
     def test_create_credential_store_returns_file_when_there_is_no_keyring(self,
                                                                            mock_keystore_wrapper):
-        provider, _ = CredentialStoreFactory.create_credential_store()
+        provider = CredentialStoreFactory.create_credential_store()
         self.assertIsInstance(provider, FileCredentialsProvider)
 
     @patch.object(KeystoreWrapper, "get_keyring_name", return_value=TEST_KEYRING)
     @patch.object(KeystoreWrapper, "is_keyring_accessible", return_value=False)
     def test_create_credential_store_returns_file_when_there_is_keyring_and_its_not_accessible(
             self, mock_keystore_wrapper, mock_another_keystore_wrapper):
-        provider, _ = CredentialStoreFactory.create_credential_store()
+        provider = CredentialStoreFactory.create_credential_store()
         self.assertIsInstance(provider, FileCredentialsProvider)

--- a/test/test_unit_logout_controller.py
+++ b/test/test_unit_logout_controller.py
@@ -60,7 +60,7 @@ class LogoutControllerTest(unittest.TestCase):
                                                                      mock_logout_logic, mock_exists,
                                                                      mock_size):
         with self.assertRaises(Exception):
-            mock_credentials_provider, _ = CredentialStoreFactory.create_credential_store()
+            mock_credentials_provider = CredentialStoreFactory.create_credential_store()
             mock_logout_controller = LogoutController(mock_logout_logic,
                                                       mock_credentials_provider)
             mock_logout_controller.remove_credentials()

--- a/test/util/test_helpers.py
+++ b/test/util/test_helpers.py
@@ -171,7 +171,7 @@ def update_policy_from_string(self, policy):
 # *************** CREDENTIALS ***************
 
 def create_cred_store():
-    cred_store, _ = CredentialStoreFactory.create_credential_store()
+    cred_store = CredentialStoreFactory.create_credential_store()
     return cred_store
 
 


### PR DESCRIPTION
### Desired Outcome

create_credential_store function currently returns a tupple. 1. credential_store, 2. the credentials source
credentials source is used for logging and exception details. there is no good reason to return a tuple here.
This pr fix this by returning credential_store instead of tuple, and added api for getting credentials source from  credential_store

### Implemented Changes

- create_credential_store return store only and not store source.
- Added get_store_location in the credential_store to get the store source

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
