### PR TITLE
Wrap http exceptions from requests lib with internal exceptions

### DIFF
--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -8,6 +8,7 @@ required to successfully configure the conjurrc
 """
 
 # Builtins
+import http
 import logging
 import sys
 
@@ -18,8 +19,8 @@ from urllib.parse import ParseResult
 # Internals
 from typing import Optional, Tuple
 from conjur.constants import DEFAULT_CERTIFICATE_FILE, DEFAULT_CONFIG_FILE, VALID_CONFIRMATIONS
-from conjur.errors import CertificateHostnameMismatchException, InvalidURLFormatException, \
-    CertificateNotTrustedException, ConfirmationException, MissingRequiredParameterException
+from conjur.errors import InvalidURLFormatException, CertificateNotTrustedException, \
+    ConfirmationException, MissingRequiredParameterException, HttpStatusError
 from conjur.util import util_functions
 from conjur.data_object import ConjurrcData
 from conjur.logic.init_logic import InitLogic
@@ -143,16 +144,11 @@ class InitController:
         if conjurrc_data.conjur_account is None:
             try:
                 self.init_logic.fetch_account_from_server(self.conjurrc_data)
-            except CertificateHostnameMismatchException:
-                raise
-            except Exception as error:
+            except HttpStatusError as error:
                 # Check for catching if the endpoint is exists. If the endpoint does not exist,
                 # a 401 status code will be returned.
                 # If the endpoint does not exist, the user will be prompted to enter in their account.
-                # pylint: disable=no-member
-                # TODO: If respone not exist in error then we will have a ecxption here
-                if hasattr(error.response, 'status_code') and str(
-                        error.response.status_code) == '401':
+                if error.status == http.HTTPStatus.UNAUTHORIZED:
                     conjurrc_data.conjur_account = input(
                         "Enter the Conjur account name (required): ").strip()
                     if conjurrc_data.conjur_account is None or conjurrc_data.conjur_account == '':

--- a/conjur/controller/policy_controller.py
+++ b/conjur/controller/policy_controller.py
@@ -6,14 +6,15 @@ PolicyController module
 This module is the controller that facilitates all list actions
 required to successfully execute the POLICY command
 """
+import http
 import sys
 
 # pylint: disable=too-few-public-methods
-import requests
 
-from conjur.errors import InvalidFormatException
+from conjur.errors import InvalidFormatException, HttpStatusError
 from conjur.logic.policy_logic import PolicyLogic
 from conjur.data_object.policy_data import PolicyData
+
 
 class PolicyController:
     """
@@ -32,11 +33,11 @@ class PolicyController:
         try:
             result = self.policy_logic.run_action(self.policy_data)
             sys.stdout.write(result+'\n')
-        except requests.exceptions.HTTPError as http_error:
-            if http_error.response.status_code == 422:
+        except HttpStatusError as http_error:
+            if http_error.status == http.HTTPStatus.UNPROCESSABLE_ENTITY:
                 raise InvalidFormatException(f"{http_error}. The policy was empty or its contents "
-                                             f"were not in valid YAML."
-                                             f"Error: {http_error.response.text}") from http_error
-            raise requests.exceptions.HTTPError(f"{http_error}."
-                                         f"Error: {http_error.response.text}",
-                                         response=http_error.response) from http_error
+                                             f"were not in valid YAML. "
+                                             f"Error: {http_error.response}") from http_error
+            raise HttpStatusError(status=http_error.status,
+                                  message=f"{http_error}. Error: {http_error.response}",
+                                  response=http_error.response) from http_error

--- a/conjur/controller/user_controller.py
+++ b/conjur/controller/user_controller.py
@@ -8,17 +8,19 @@ This module is the controller that facilitates all user actions
 
 # Builtins
 import getpass
+import http
 import logging
 import sys
-import requests
 
 # Internals
 from conjur.errors import InvalidPasswordComplexityException, \
-    OperationNotCompletedException
+    OperationNotCompletedException, HttpError, HttpStatusError
 from conjur.errors_messages import PASSWORD_COMPLEXITY_CONSTRAINTS_MESSAGE
 from conjur.logic.user_logic import UserLogic
 from conjur.data_object.user_input_data import UserInputData
-class UserController():
+
+
+class UserController:
     """
     UserController
 
@@ -49,8 +51,9 @@ class UserController():
         self.prompt_for_password()
         try:
             self.user_input_data.user_id, _ = self.user_logic.change_personal_password(self.user_input_data.new_password)
-        except requests.exceptions.HTTPError as http_error:
-            if http_error.response.status_code == 401:
+        except HttpError as http_error:
+            # pylint: disable=no-member
+            if isinstance(http_error, HttpStatusError) and http_error.status == http.HTTPStatus.UNAUTHORIZED:
                 raise
 
             logging.debug(f"Invalid password {PASSWORD_COMPLEXITY_CONSTRAINTS_MESSAGE}")

--- a/conjur/errors.py
+++ b/conjur/errors.py
@@ -168,3 +168,21 @@ class KeyringWrapperSetError(KeyringWrapperGeneralError):
     def __init__(self, message: str = ""):
         self.message = message
         super().__init__(self.message)
+
+class HttpError(Exception):
+    """ Base exception for general HTTP failures """
+    def __init__(self, message: str = "HTTP request failed", response: str = ""):
+        self.message = message
+        self.response = response
+        super().__init__(self.message)
+
+class HttpStatusError(HttpError):
+    """ Exception for HTTP status failures """
+    def __init__(self, status: str, message: str = "HTTP request failed", response: str = ""):
+        self.status = status
+        super().__init__(message=message, response=response)
+
+class HttpSslError(HttpError):
+    """ Exception for HTTP SSL failures """
+    def __init__(self, message: str = "HTTP request failed with SSL error"):
+        super().__init__(message=message)

--- a/conjur/logic/credential_provider/credential_store_factory.py
+++ b/conjur/logic/credential_provider/credential_store_factory.py
@@ -30,11 +30,11 @@ class CredentialStoreFactory:
         """
         Factory method for determining which store to use
         """
-
-        if KeystoreWrapper.get_keyring_name() in SUPPORTED_BACKENDS:
+        keyring_name = KeystoreWrapper.get_keyring_name()
+        if keyring_name in SUPPORTED_BACKENDS:
             # If the keyring is unlocked then we will use it
             if KeystoreWrapper.is_keyring_accessible():
                 # pylint: disable=line-too-long
-                return KeystoreCredentialsProvider(), f'{KeystoreWrapper.get_keyring_name()} credential store'
+                return KeystoreCredentialsProvider(), f'{keyring_name} credential store'
 
         return FileCredentialsProvider(), DEFAULT_NETRC_FILE

--- a/conjur/logic/login_logic.py
+++ b/conjur/logic/login_logic.py
@@ -60,7 +60,7 @@ class LoginLogic:
         logging.debug("API key retrieved from Conjur")
         return api_key
 
-    def save(self, credential_data:CredentialsData):
+    def save(self, credential_data: CredentialsData):
         """
         Method to save credentials during login
         """

--- a/conjur/logic/user_logic.py
+++ b/conjur/logic/user_logic.py
@@ -12,7 +12,7 @@ from typing import Tuple
 import requests
 
 # Internals
-from conjur.errors import OperationNotCompletedException
+from conjur.errors import OperationNotCompletedException, HttpError
 from conjur.interface.credentials_store_interface import CredentialsStoreInterface
 from conjur.resource import Resource
 from conjur.data_object import ConjurrcData, CredentialsData
@@ -101,10 +101,10 @@ class UserLogic:
             self.update_api_key_in_credential_store(logged_in_username,
                                                     logged_in_credentials,
                                                     new_api_key)
-        except requests.exceptions.HTTPError:
+        except HttpError:
             raise
         except Exception as incomplete_operation:
-            raise OperationNotCompletedException(incomplete_operation) from incomplete_operation
+            raise OperationNotCompletedException(str(incomplete_operation)) from incomplete_operation
         return new_api_key
 
     # pylint: disable=line-too-long

--- a/conjur/util/util_functions.py
+++ b/conjur/util/util_functions.py
@@ -7,13 +7,13 @@ This module holds the common logic across the codebase
 """
 
 # Builtins
+import http
 import logging
 import platform
 import os
-from requests.exceptions import HTTPError
 
 # Internals
-from conjur.errors import MissingRequiredParameterException
+from conjur.errors import MissingRequiredParameterException, HttpError
 from conjur.util.os_types import OSTypes
 from conjur.constants import KEYRING_TYPE_ENV_VARIABLE_NAME, \
     MAC_OS_KEYRING_NAME, LINUX_KEYRING_NAME, WINDOWS_KEYRING_NAME
@@ -55,9 +55,9 @@ def get_insecure_warning_in_debug():
                   "makes your system vulnerable to security attacks")
 
 
-def determine_status_code_specific_error_messages(server_error: HTTPError) -> str:
+def determine_status_code_specific_error_messages(server_error: HttpError) -> str:
     """ Method for returning status code-specific error messages """
-    if str(server_error.response.status_code) == '401':
+    if server_error.status == http.HTTPStatus.UNAUTHORIZED:
         return "Failed to log in to Conjur. Unable to authenticate with Conjur. " \
                f"Reason: {server_error}. Check your credentials and try again.\n"
     return f"Failed to execute command. Reason: {server_error}\n"

--- a/test/test_integration_configurations.py
+++ b/test/test_integration_configurations.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import requests
 
 from conjur.data_object import CredentialsData
+from conjur.errors import HttpSslError
 from conjur.errors_messages import FETCH_CONFIGURATION_FAILURE_MESSAGE
 from test.util.test_infrastructure import integration_test
 from test.util.test_runners.integration_test_case import IntegrationTestCaseBase
@@ -242,7 +243,7 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
         cred_store.save(credential_data)
         self.setup_cli_params({})
 
-        self.print_instead_of_raise_error(requests.exceptions.SSLError, "SSLError", exit_code=1)
+        self.print_instead_of_raise_error(HttpSslError, "SSLError", exit_code=1)
 
     """
     DEVELOPER NOTE:
@@ -266,7 +267,7 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
         cred_store.save(credential_data)
         self.setup_cli_params({})
 
-        self.print_instead_of_raise_error(requests.exceptions.SSLError, "SSLError", exit_code=1)
+        self.print_instead_of_raise_error(HttpSslError, "SSLError", exit_code=1)
 
     """
     This test checks that a conjurrc in an improper format (v4 format) fails on the proper, 

--- a/test/test_integration_credentials_keyring.py
+++ b/test/test_integration_credentials_keyring.py
@@ -70,7 +70,7 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
         output = self.invoke_cli(self.cli_auth_params,
                                  ['login', '-i', 'admin', '-p', self.client_params.env_api_key], exit_code=1)
         self.assertIn("The client was initialized without", output)
-        self.assertEquals(utils.is_netrc_exists(), False)
+        self.assertFalse(utils.is_netrc_exists())
 
     '''
     Validates that if a user configures the CLI in insecure mode and runs a command in 
@@ -79,6 +79,7 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
     @integration_test(True)
     @patch('builtins.input', return_value='yes')
     def test_cli_configured_in_insecure_mode_and_run_in_insecure_mode_passes_keyring(self, mock_input):
+        utils.remove_file(DEFAULT_NETRC_FILE)
         self.invoke_cli(self.cli_auth_params,
                         ['--insecure', 'init', '--url', self.client_params.hostname, '--account',
                          self.client_params.account])
@@ -86,7 +87,7 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
         output = self.invoke_cli(self.cli_auth_params,
                                  ['--insecure', 'login', '-i', 'admin', '-p', self.client_params.env_api_key])
         self.assertIn('Successfully logged in to Conjur', output)
-        self.assertEquals(utils.is_netrc_exists(), False)
+        self.assertFalse(utils.is_netrc_exists())
 
     '''
     Validates that if a user runs in insecure mode without supplying inputs, 
@@ -141,7 +142,7 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
         self.assertIn("Successfully logged in to Conjur", output.strip())
         utils.get_credentials()
         self.validate_credentials(f"{self.client_params.hostname}", "someuser", extract_api_key_from_message)
-        self.assertEquals(utils.is_netrc_exists(), False)
+        self.assertFalse(utils.is_netrc_exists())
 
     '''
     Validate that login create valid credentials
@@ -153,7 +154,7 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
                         ['login', '-i', 'admin', '-p', self.client_params.env_api_key])
         utils.get_credentials()
         self.validate_credentials(f"{self.client_params.hostname}", "admin", self.client_params.env_api_key)
-        self.assertEquals(utils.is_netrc_exists(), False)
+        self.assertFalse(utils.is_netrc_exists())
 
     '''
     Validate correct message when try to logout already logout user
@@ -219,7 +220,7 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
             self.assertIn("Successfully logged in to Conjur", output.strip())
 
             self.validate_credentials(f"{self.client_params.hostname}", "admin", self.client_params.env_api_key)
-            self.assertEquals(utils.is_netrc_exists(), False)
+            self.assertFalse(utils.is_netrc_exists())
 
     '''
     Validates interactively provided params create credentials
@@ -233,7 +234,7 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
             assert utils.get_credentials() is not None
             self.assertIn("Successfully logged in to Conjur", output.strip())
             self.validate_credentials(f"{self.client_params.hostname}", "admin", self.client_params.env_api_key)
-            self.assertEquals(utils.is_netrc_exists(), False)
+            self.assertFalse(utils.is_netrc_exists())
 
     '''
     Validates login is successful for hosts
@@ -264,7 +265,7 @@ class CliIntegrationTestCredentialsKeyring(IntegrationTestCaseBase):
 
         self.validate_credentials(f"{self.client_params.hostname}", "host/somehost", extract_api_key_from_message)
         self.assertIn("Successfully logged in to Conjur", output.strip())
-        self.assertEquals(utils.is_netrc_exists(), False)
+        self.assertFalse(utils.is_netrc_exists())
 
     '''
     Validates logout doesn't remove an irrelevant entry

--- a/test/test_integration_policy.py
+++ b/test/test_integration_policy.py
@@ -121,7 +121,7 @@ class CliIntegrationPolicy(IntegrationTestCaseBase):  # pragma: no cover
         with redirect_stderr(self.capture_stream):
             output = utils.load_policy_from_string(self, policy_with_bad_syntax, exit_code=1)
         self.assertIn("{\"error\":{\"code\":\"validation_failed\",\"message\":", output, 
-                        "Could not find detailed error in the output."
+                        "Could not find detailed error in the output. "
                         "Expected to find:"
                         "{\"error\":{\"code\":\"validation_failed\",\"message\":"
                         "Result:"
@@ -134,7 +134,7 @@ class CliIntegrationPolicy(IntegrationTestCaseBase):  # pragma: no cover
                            ['policy', 'load', '-b', 'wrong-branch', '-f', 
                            self.environment.path_provider.get_policy_path("resource")], exit_code=1)
         self.assertIn("{\"error\":{\"code\":\"not_found\",\"message\":", output, 
-                        "Could not find detailed error in the output."
+                        "Could not find detailed error in the output. "
                         "Expected to find:"
                         "{\"error\":{\"code\":\"not_found\",\"message\":"
                         "Result:"

--- a/test/test_unit_http.py
+++ b/test/test_unit_http.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, call, MagicMock
 
 import requests
 
+from conjur.errors import HttpSslError
 from conjur.wrapper.http_wrapper import HttpVerb, invoke_endpoint
 
 
@@ -84,7 +85,7 @@ class HttpInvokeEndpointTest(unittest.TestCase):
 
         mock_get.assert_called_once_with('no/params', auth=None, verify=True, headers={}, params=None)
 
-    @patch.object(requests, 'get', side_effect=[requests.exceptions.SSLError(), None])
+    @patch.object(requests, 'get', side_effect=[HttpSslError(), None])
     def test_invoke_endpoint_passes_ssl_verify_param_and_tries_verify_true_first_to_http_client(self, mock_get):
         invoke_endpoint(HttpVerb.GET, self.MockEndpoint.NO_PARAMS, None, ssl_verify='foo', check_errors=False)
         calls = [call('no/params', auth=None, verify=True, headers={}, params=None), call('no/params', auth=None, verify='foo', headers={}, params=None)]
@@ -93,9 +94,9 @@ class HttpInvokeEndpointTest(unittest.TestCase):
     @patch.object(requests, 'get')
     def test_invoke_endpoint_raises_hostname_mismatch_error(self, mock_get):
         mock = MagicMock()
-        mock.response="hostname"
-        mock_get.side_effect=requests.exceptions.SSLError(response=mock.response)
-        with self.assertRaises(requests.exceptions.SSLError):
+        mock.response = "hostname"
+        mock_get.side_effect = requests.exceptions.SSLError(response=mock.response)
+        with self.assertRaises(HttpSslError):
             invoke_endpoint(HttpVerb.GET, self.MockEndpoint.NO_PARAMS, None, ssl_verify='foo', check_errors=False)
 
     @patch.object(requests, 'get')

--- a/test/test_unit_init_controller.py
+++ b/test/test_unit_init_controller.py
@@ -8,8 +8,8 @@ import requests
 from OpenSSL import SSL
 
 from conjur.constants import TEST_HOSTNAME
-from conjur.errors import CertificateHostnameMismatchException, InvalidURLFormatException,\
-    CertificateNotTrustedException, MissingRequiredParameterException
+from conjur.errors import CertificateHostnameMismatchException, InvalidURLFormatException, \
+    CertificateNotTrustedException, MissingRequiredParameterException, HttpSslError, HttpStatusError
 from conjur.logic.init_logic import InitLogic as InitLogic
 from conjur.controller.init_controller import InitController as InitController
 from conjur.data_object.conjurrc_data import ConjurrcData
@@ -46,9 +46,7 @@ class InitControllerTest(unittest.TestCase):
     @patch('builtins.input', return_value='')
     @patch('conjur.logic.init_logic')
     def test_init_without_host_raises_error(self, mock_init_logic, mock_input):
-        mock_response = MagicMock()
-        mock_response.status_code = 401
-        mock_init_logic.fetch_account_from_server = MagicMock(side_effect=requests.exceptions.SSLError(response=mock_response))
+        mock_init_logic.fetch_account_from_server = MagicMock(side_effect=HttpStatusError(status=401))
         mock_conjurrc_data = ConjurrcData()
         with self.assertRaises(MissingRequiredParameterException):
             mock_conjurrc_data.conjur_url = 'https://someurl'
@@ -58,9 +56,7 @@ class InitControllerTest(unittest.TestCase):
     @patch('builtins.input', return_value='someaccount')
     @patch('conjur.logic.init_logic')
     def test_init_host_is_added_to_conjurrc_object(self, mock_init_logic, mock_input):
-        mock_response = MagicMock()
-        mock_response.status_code = 401
-        mock_init_logic.fetch_account_from_server = MagicMock(side_effect=requests.exceptions.SSLError(response=mock_response))
+        mock_init_logic.fetch_account_from_server = MagicMock(side_effect=HttpStatusError(status=401))
         mock_conjurrc_data = ConjurrcData()
         mock_conjurrc_data.conjur_url="https://someaccount"
         mock_init_controller = InitController(mock_conjurrc_data, mock_init_logic, False, True)

--- a/test/test_unit_login_controller.py
+++ b/test/test_unit_login_controller.py
@@ -2,7 +2,8 @@ import unittest
 from unittest.mock import MagicMock, patch
 import requests
 
-from conjur.errors import CertificateVerificationException, MissingRequiredParameterException
+from conjur.errors import CertificateVerificationException, MissingRequiredParameterException, \
+    HttpError
 from conjur.util import util_functions
 from conjur.data_object.credentials_data import CredentialsData
 from conjur.controller.login_controller import LoginController
@@ -95,7 +96,7 @@ class LoginControllerTest(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.status_code = 401
         with patch('conjur.logic.login_logic') as mock_logic:
-            mock_logic.get_api_key = MagicMock(side_effect=requests.exceptions.HTTPError(response=mock_response))
+            mock_logic.get_api_key = MagicMock(side_effect=HttpError(response=mock_response))
             mock_login_controller = LoginController(True, None, MockCredentialsData, mock_logic)
-            with self.assertRaises(requests.exceptions.HTTPError):
+            with self.assertRaises(HttpError):
                 mock_login_controller.get_api_key(MockCredentialsData)

--- a/test/test_unit_policy_controller.py
+++ b/test/test_unit_policy_controller.py
@@ -5,27 +5,24 @@ import requests
 
 import conjur
 from conjur import Client
+from conjur.errors import HttpStatusError
 from conjur.logic.policy_logic import PolicyLogic
 from conjur.controller.policy_controller import PolicyController
 
 
 class PolicyControllerTest(unittest.TestCase):
     def test_policy_syntax_error_raises_unprocessable_exception(self):
-        mock_response = MagicMock()
-        mock_response.status_code = 422
         client = Client
         mock_policy_logic = PolicyLogic(client)
         mock_policy_controller = PolicyController(mock_policy_logic, "somedata")
-        mock_policy_logic.run_action = MagicMock(side_effect=requests.exceptions.HTTPError(response=mock_response))
+        mock_policy_logic.run_action = MagicMock(side_effect=HttpStatusError(status=422))
         with self.assertRaises(conjur.errors.InvalidFormatException):
             mock_policy_controller.load()
 
     def test_policy_syntax_error_raises_general_https_exception(self):
-        mock_response = MagicMock()
-        mock_response.status_code = 404
         client = Client
         mock_policy_logic = PolicyLogic(client)
         mock_policy_controller = PolicyController(mock_policy_logic, "somedata")
-        mock_policy_logic.run_action = MagicMock(side_effect=requests.exceptions.HTTPError(response=mock_response))
-        with self.assertRaises(requests.exceptions.HTTPError):
+        mock_policy_logic.run_action = MagicMock(side_effect=HttpStatusError(status=404))
+        with self.assertRaises(HttpStatusError):
             mock_policy_controller.load()

--- a/test/test_unit_user_controller.py
+++ b/test/test_unit_user_controller.py
@@ -2,7 +2,8 @@ import unittest
 from unittest.mock import MagicMock, patch
 import requests
 
-from conjur.errors import OperationNotCompletedException, InvalidPasswordComplexityException
+from conjur.errors import OperationNotCompletedException, InvalidPasswordComplexityException, \
+    HttpError, HttpStatusError
 from conjur.controller.user_controller import UserController
 from conjur.logic.user_logic import UserLogic
 from conjur.data_object.user_input_data import UserInputData
@@ -36,14 +37,11 @@ class UserControllerTest(unittest.TestCase):
 
     @patch('conjur.logic.user_logic')
     def test_change_password_can_raise_authn_error(self, mock_user_logic):
-        # mock the status code of the error received
-        mock_response = MagicMock()
-        mock_response.status_code = 401
         user_controller = UserController(mock_user_logic, self.user_input_data)
         user_controller.prompt_for_password = MagicMock()
         mock_user_logic.change_personal_password = MagicMock(
-            side_effect=requests.exceptions.HTTPError(response=mock_response))
-        with self.assertRaises(requests.exceptions.HTTPError):
+            side_effect=HttpStatusError(status=401))
+        with self.assertRaises(HttpError):
             user_controller.change_personal_password()
 
     @patch('conjur.logic.user_logic')
@@ -54,7 +52,7 @@ class UserControllerTest(unittest.TestCase):
         user_controller = UserController(mock_user_logic, self.user_input_data)
         user_controller.prompt_for_password = MagicMock()
         mock_user_logic.change_personal_password = MagicMock(
-            side_effect=requests.exceptions.HTTPError(response=mock_response))
+            side_effect=HttpError(response=mock_response))
         with self.assertRaises(InvalidPasswordComplexityException):
             user_controller.change_personal_password()
 

--- a/test/test_unit_user_logic.py
+++ b/test/test_unit_user_logic.py
@@ -4,7 +4,7 @@ import requests
 
 from conjur import Client
 from conjur.data_object import CredentialsData
-from conjur.errors import OperationNotCompletedException
+from conjur.errors import OperationNotCompletedException, HttpError
 from conjur.data_object.conjurrc_data import ConjurrcData
 from conjur.logic.credential_provider.file_credentials_provider import FileCredentialsProvider
 from conjur.logic.user_logic import UserLogic
@@ -97,10 +97,10 @@ class UserLogicTest(unittest.TestCase):
     Raises exception when HTTPError was raised
     '''
     def test_rotate_personal_api_key_raises_exception_when_unauthorized(self):
-        with self.assertRaises(requests.exceptions.HTTPError):
+        with self.assertRaises(HttpError):
             client = MagicMock(return_value=None)
             mock_user_logic = UserLogic(ConjurrcData, FileCredentialsProvider, client)
-            mock_user_logic.client.rotate_personal_api_key = MagicMock(side_effect=requests.exceptions.HTTPError)
+            mock_user_logic.client.rotate_personal_api_key = MagicMock(side_effect=HttpError)
             mock_user_logic.rotate_personal_api_key('someuser', 'somecreds', 'somepass')
 
     '''

--- a/test/util/test_helpers.py
+++ b/test/util/test_helpers.py
@@ -211,9 +211,7 @@ def save_credentials(credentials):
 
 
 def is_netrc_exists():
-    if not os.path.exists(DEFAULT_NETRC_FILE) or os.path.getsize(DEFAULT_NETRC_FILE) == 0:
-        return False
-    return True
+    return os.path.exists(DEFAULT_NETRC_FILE) and os.path.getsize(DEFAULT_NETRC_FILE) > 0
 
 
 # *************************************************


### PR DESCRIPTION
http_wrapper should not throw exceptions from its internal
library, `requests`.
Instead, it takes the necessary info from the exceptions and use it
to create new internal exception.
This will allow replacing `requests` lib without impacting code
outside of http_wrapper.

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
