### PR TITLE
Client to work with ssl verification modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `hostfactory` method `create token` is now available in CLI and SDK to create a hostfactory token 
   to manage hosts and permissions in a dynamic way
   [cyberark/conjur-api-python3#339](https://github.com/cyberark/conjur-api-python3/pull/339)
+- Stop supporting `Client` initialization from disk.
 
 ## [7.0.1] - 2020-04-12
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # conjur-api-python3
 
-This repository includes both the self-contained Conjur command-line tool (`conjur`) and the Python3-based SDK for accessing 
-the Conjur API to manage Conjur resources.
+This repository includes both the self-contained Conjur command-line tool (`conjur`) and the
+Python3-based SDK for accessing the Conjur API to manage Conjur resources.
 
 [![Test Coverage](https://api.codeclimate.com/v1/badges/d90d69a3942120b36785/test_coverage)](https://codeclimate.com/github/cyberark/conjur-api-python3/test_coverage) [![Maintainability](https://api.codeclimate.com/v1/badges/d90d69a3942120b36785/maintainability)](https://codeclimate.com/github/cyberark/conjur-api-python3/maintainability)
 
@@ -13,28 +13,34 @@ the Conjur API to manage Conjur resources.
 
 ![](https://img.shields.io/badge/Certification%20Level-Certified-6C757D?link=https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md)
 
-The Conjur CLI is a **Certified** level project. It's been reviewed by CyberArk to verify that it will securely
-work with CyberArk Conjur Enterprise (previously known as DAP) as documented. In addition, CyberArk offers 
-Enterprise-level support for these features. For more detailed information on our certification levels, 
-see [our community guidelines](https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md#community).
+The Conjur CLI is a **Certified** level project. It's been reviewed by CyberArk to verify that it
+will securely work with CyberArk Conjur Enterprise (previously known as DAP) as documented. In
+addition, CyberArk offers Enterprise-level support for these features. For more detailed information
+on our certification levels,
+see [our community guidelines](https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md#community)
+.
 
 ### Conjur Python SDK
 
 ![](https://img.shields.io/badge/Certification%20Level-Community-28A745?link=https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md)
 
-The Conjur Python SDK is a **Community** level project. It's a community contributed project that **is not reviewed or supported
-by CyberArk**. For more detailed information on our certification levels, see [our community guidelines](https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md#community).
+The Conjur Python SDK is a **Community** level project. It's a community contributed project that **
+is not reviewed or supported by CyberArk**. For more detailed information on our certification
+levels,
+see [our community guidelines](https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md#community)
+.
 
-### Using conjur-api-python3 with Conjur Open Source 
+### Using conjur-api-python3 with Conjur Open Source
 
-Are you using this project with [Conjur Open Source](https://github.com/cyberark/conjur)? Then we 
-**strongly** recommend choosing the version of this project to use from the latest [Conjur OSS 
-suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html). 
-Conjur maintainers perform additional testing on the suite release versions to ensure 
-compatibility. When possible, upgrade your Conjur Open Source version to match the 
-[latest suite release](https://docs.conjur.org/Latest/en/Content/ReleaseNotes/ConjurOSS-suite-RN.htm).
-When using integrations, choose the latest suite release that matches your Conjur Open Source version. For any 
-questions, please contact us on [Discourse](https://discuss.cyberarkcommons.org/c/conjur/5).
+Are you using this project with [Conjur Open Source](https://github.com/cyberark/conjur)? Then we
+**strongly** recommend choosing the version of this project to use from the
+latest [Conjur OSS suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html)
+. Conjur maintainers perform additional testing on the suite release versions to ensure
+compatibility. When possible, upgrade your Conjur Open Source version to match the
+[latest suite release](https://docs.conjur.org/Latest/en/Content/ReleaseNotes/ConjurOSS-suite-RN.htm)
+. When using integrations, choose the latest suite release that matches your Conjur Open Source
+version. For any questions, please contact us
+on [Discourse](https://discuss.cyberarkcommons.org/c/conjur/5).
 
 ### Supported Services
 
@@ -51,16 +57,18 @@ questions, please contact us on [Discourse](https://discuss.cyberarkcommons.org/
 
 #### Install the Conjur CLI
 
-To access the latest release of the Conjur CLI, go to our [release](https://github.com/cyberark/conjur-api-python3/releases) 
-page. For instructions on how to set up and configure the CLI, see our [official documentation](https://docs.conjur.org/Latest/en/Content/Developer/CLI/cli-lp.htm).
+To access the latest release of the Conjur CLI, go to
+our [release](https://github.com/cyberark/conjur-api-python3/releases)
+page. For instructions on how to set up and configure the CLI, see
+our [official documentation](https://docs.conjur.org/Latest/en/Content/Developer/CLI/cli-lp.htm).
 
 #### Install the SDK
 
-The SDK can be installed via PyPI. Note that the SDK is a **Community** level project meaning 
-that the SDK is subject to alterations that may result in breaking change. 
+The SDK can be installed via PyPI. Note that the SDK is a **Community** level project meaning that
+the SDK is subject to alterations that may result in breaking change.
 
-To avoid unanticipated breaking changes, make sure that you stay up-to-date on our 
-latest releases and review the project's [CHANGELOG.md](CHANGELOG.md).
+To avoid unanticipated breaking changes, make sure that you stay up-to-date on our latest releases
+and review the project's [CHANGELOG.md](CHANGELOG.md).
 
 ```
 pip3 install conjur
@@ -68,8 +76,8 @@ pip3 install conjur
 conjur --help
 ```
 
-Alternatively, you can install the library from the source. Note that this will install the latest work from the
-cloned source and not necessarily an official release. 
+Alternatively, you can install the library from the source. Note that this will install the latest
+work from the cloned source and not necessarily an official release.
 
 Clone the project and run:
 
@@ -81,13 +89,12 @@ pip3 install
 
 ### CLI
 
-For more information on how to set up, configure, and start using the Conjur CLI, see our [official 
-documentation](https://docs.conjur.org/Latest/en/Content/Developer/CLI/cli-lp.htm).
+For more information on how to set up, configure, and start using the Conjur CLI, see
+our [official documentation](https://docs.conjur.org/Latest/en/Content/Developer/CLI/cli-lp.htm).
 
 ### SDK
 
-To start using the SDK in your applications, create a Client instance and then invoke the 
-API on it:
+To start using the SDK in your applications, create a Client instance and then invoke the API on it:
 
 #### With login ID and password
 
@@ -96,11 +103,10 @@ API on it:
 
 from conjur import Client
 
-client = Client(url='https://conjur.myorg.com',
-                account='default',
-                login_id='admin',
-                password='mypassword',
-                ca_bundle='/path/to/my/ca/bundle.pem')
+client = Client(conjurrc_data=ConjurrcData(...),
+                ssl_verification_mode=SslVerificationMode.WITH_TRUST_STORE.,
+                credentials_provider=FileCredentialsProvider(),
+                debug=False)
 
 print("Setting variable...")
 client.set('conjur/my/variable', 'new value')
@@ -111,26 +117,14 @@ new_value = client.get('conjur/my/variable')
 print("Variable value is:", new_value.decode('utf-8'))
 ```
 
-#### With login ID and API key
-
-Write the code as in the first example but initialize the Client with the following arguments:
-
-```python3
-client = Client(url='https://conjur.myorg.com',
-                account='default',
-                login_id='admin',
-                api_key='myapikey',
-                ca_bundle='/path/to/my/ca/bundle.pem')
-```
-
 #### Defining the Conjur server endpoint
 
-A configuration file called `.conjurrc` is used to hold details required to communicate 
-to the Conjur server. You can provide these details needed to open a connection to the 
-Conjur endpoint in this file instead of passing them in (`url`, `account`, and `ca_bundle`)  
+A configuration file called `.conjurrc` is used to hold details required to communicate to the
+Conjur server. You can provide these details needed to open a connection to the Conjur endpoint in
+this file instead of passing them in (`url`, `account`, and `ca_bundle`)  
 during initialization of the Client.
 
-The `.conjurrc` file should be saved to your home directory and should contain `conjur_url`, 
+The `.conjurrc` file should be saved to your home directory and should contain `conjur_url`,
 `conjur_account`, and`cert_file`.
 
 ```
@@ -143,20 +137,20 @@ conjur_url: https://conjur-server
 
 #### Storing credentials
 
-When using the SDK, you can keep credentials in the system's native credential store 
-instead of passing them in during initialization of the Client. By default, the Client 
-will favor saving credentials (login ID and password) to the system's credential store. 
-If the detected credential store is not one we support or is not accessible, the 
-credentials will be written to a configuration file, `.netrc`, in plaintext. 
+When using the SDK, you can keep credentials in the system's native credential store instead of
+passing them in during initialization of the Client. By default, the Client will favor saving
+credentials (login ID and password) to the system's credential store. If the detected credential
+store is not one we support or is not accessible, the credentials will be written to a configuration
+file, `.netrc`, in plaintext.
 
-If written to the `.netrc`, it is strongly recommended that you log out when not 
-using the Conjur CLI. This removes the credentials from the `.netrc` file.
+If written to the `.netrc`, it is strongly recommended that you log out when not using the Conjur
+CLI. This removes the credentials from the `.netrc` file.
 
-The `.netrc` file or (`_netrc` for Windows environments) contains credentials needed to log in to the 
-Conjur endpoint and should consist of 'machine', 'login', and 'password'.
+The `.netrc` file or (`_netrc` for Windows environments) contains credentials needed to log in to
+the Conjur endpoint and should consist of 'machine', 'login', and 'password'.
 
-Note that if you choose to create this file yourself, ensure you follow least privilege, allowing only the
-user who has created the file to have read/write permissions on it (`chmod 700 .netrc`).
+Note that if you choose to create this file yourself, ensure you follow least privilege, allowing
+only the user who has created the file to have read/write permissions on it (`chmod 700 .netrc`).
 
 ```
 # .netrc / _netrc
@@ -165,60 +159,48 @@ login admin
 password 1234....
 ```
 
-If you store connection details in the `conjurrc` and use a credential store or `netrc` for 
-storing credentials, you can create the Client in the following way and the details will 
-be extracted implicitly:
-
-```
-client = Client()
-```
-
 ## Supported Client methods
 
 #### `get(variable_id)`
 
-Gets a variable value based on its ID. Variable is binary data
-that should be decoded to your system's encoding (e.g.
+Gets a variable value based on its ID. Variable is binary data that should be decoded to your
+system's encoding (e.g.
 `get(variable_id).decode('utf-8')`.
 
 #### `get_many(variable_id[,variable_id...])`
 
-Gets multiple variable values based on their IDs. Variables are
-returned in a dictionary that maps the variable name to its value.
+Gets multiple variable values based on their IDs. Variables are returned in a dictionary that maps
+the variable name to its value.
 
 #### `set(variable_id, value)`
 
 Sets a variable to a specific value based on its ID.
 
-Note: Policy to create the variable must have already been loaded
-otherwise you will get a 404 error during invocation.
+Note: Policy to create the variable must have already been loaded otherwise you will get a 404 error
+during invocation.
 
 #### `load_policy_file(policy_name, policy_file)`
 
-Applies a file-based YAML to a named policy. This method only
-supports additive changes. Result is a dictionary object constructed
-from the returned JSON data.
+Applies a file-based YAML to a named policy. This method only supports additive changes. Result is a
+dictionary object constructed from the returned JSON data.
 
 #### `replace_policy_file(policy_name, policy_file)`
 
-Replaces a named policy with one from the provided file. This is
-usually a destructive invocation. Result is a dictionary object
-constructed from the returned JSON data.
+Replaces a named policy with one from the provided file. This is usually a destructive invocation.
+Result is a dictionary object constructed from the returned JSON data.
 
 #### `update_policy_file(policy_name, policy_file)`
 
-Modifies an existing Conjur policy. Data may be explicitly
-deleted using the `!delete`, `!revoke`, and `!deny` statements. Unlike
-"replace" mode, no data is ever implicitly deleted. Result is a
-dictionary object constructed from the returned JSON data.
+Modifies an existing Conjur policy. Data may be explicitly deleted using the `!delete`, `!revoke`,
+and `!deny` statements. Unlike
+"replace" mode, no data is ever implicitly deleted. Result is a dictionary object constructed from
+the returned JSON data.
 
 #### `list(list_constraints)`
 
-Returns a list of all available resources for the current
-account.
+Returns a list of all available resources for the current account.
 
-The 'list constraints' parameter is optional and should be provided as
-a dictionary.
+The 'list constraints' parameter is optional and should be provided as a dictionary.
 
 For example: `client.list({'kind': 'user', 'inspect': True})`
 
@@ -235,7 +217,7 @@ For example: `client.list({'kind': 'user', 'inspect': True})`
 
 Rotates another entity's API key and returns it as a string.
 
-Note: resource is of type Resource which should have `type` (user / host) and 
+Note: resource is of type Resource which should have `type` (user / host) and
 `name` attributes.
 
 #### `rotate_personal_api_key(logged_in_user, current_password)`
@@ -244,23 +226,24 @@ Rotates the personal API key of the logged-in user and returns it as a string.
 
 #### `change_personal_password(logged_in_user, current_password, new_password)`
 
-Updates the current, logged-in user's password with the password parameter provided. 
+Updates the current, logged-in user's password with the password parameter provided.
 
-Note: the new password must meet the Conjur password complexity constraints. It must 
-contain at least 12 characters: 2 uppercase, 2 lowercase, 1 digit, 1 special character.
+Note: the new password must meet the Conjur password complexity constraints. It must contain at
+least 12 characters: 2 uppercase, 2 lowercase, 1 digit, 1 special character.
 
 #### `whoami()`
 
 _Note: This method requires Conjur v1.9+_
 
-Returns a Python dictionary of information about the Client making an
-API request (such as its IP address, user, account, token expiration 
-date, etc).
+Returns a Python dictionary of information about the Client making an API request (such as its IP
+address, user, account, token expiration date, etc).
 
 ## Contributing
 
-Instructions for how to deploy a deployment environment and run project tests can be found in [CONTRIBUTING.md](CONTRIBUTING.md).
+Instructions for how to deploy a deployment environment and run project tests can be found
+in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-This project is [licensed under Apache License v2.0](LICENSE.md). Copyright (c) 2021 CyberArk Software Ltd. All rights reserved.
+This project is [licensed under Apache License v2.0](LICENSE.md). Copyright (c) 2021 CyberArk
+Software Ltd. All rights reserved.

--- a/conjur/api/errors.py
+++ b/conjur/api/errors.py
@@ -9,3 +9,7 @@ This module holds Conjur SDK-specific errors for this project
 
 class CertificateHostnameMismatchException(Exception):
     """ Thrown to indicate that a mismatch in the certificate hostname. """
+
+
+class BadInitializationException(Exception):
+    """ Thrown to indicate object that initialized in an invalid way. """

--- a/conjur/api/models/__init__.py
+++ b/conjur/api/models/__init__.py
@@ -1,0 +1,8 @@
+"""
+api.models
+
+Package containing models for being exposed by conjur sdk
+"""
+
+from conjur.api.models.ssl_verification_mode import SslVerificationMode
+from conjur.api.models.ssl_verification_metadata import SslVerificationMetadata

--- a/conjur/api/models/ssl_verification_metadata.py
+++ b/conjur/api/models/ssl_verification_metadata.py
@@ -1,0 +1,31 @@
+"""
+SslVerificationMetaData module
+This module holds the SslVerificationData class
+
+"""
+from conjur.api.errors import BadInitializationException
+from conjur.api.models.ssl_verification_mode import SslVerificationMode
+
+
+# pylint: disable=too-few-public-methods
+class SslVerificationMetadata:
+    """
+    A data class that is used by http_wrapper to preform TLS operations
+    """
+
+    def __init__(self, mode: SslVerificationMode, ca_cert_path: str = None):
+        self.mode = mode
+        self.ca_cert_path = ca_cert_path
+        self._validate_input()
+
+    def _validate_input(self):
+        requires_cert_options = [SslVerificationMode.WITH_CA_BUNDLE,
+                                 SslVerificationMode.SELF_SIGN]
+        if self.mode in requires_cert_options and not self.ca_cert_path:
+            # TODO check if file exist and have read permissions
+            raise BadInitializationException(
+                f"SslVerificationMetaData was initialized incorrect with "
+                f"mode: {self.mode} and ca_cert_path: {self.ca_cert_path}")
+
+    def __eq__(self, other):
+        return self.mode == other.mode and self.ca_cert_path == other.ca_cert_path

--- a/conjur/api/models/ssl_verification_mode.py
+++ b/conjur/api/models/ssl_verification_mode.py
@@ -5,7 +5,7 @@ This module is used to represent different types of SSL verification options
 from enum import Enum
 
 
-class SslVerificationModes(Enum):
+class SslVerificationMode(Enum):
     """
     Enumeration of all possible certificate methods that we may use against
     """

--- a/conjur/data_object/conjurrc_data.py
+++ b/conjur/data_object/conjurrc_data.py
@@ -16,7 +16,7 @@ except ImportError:  # pragma: no cover
 
 # Internals
 from conjur.constants import DEFAULT_CONFIG_FILE
-from conjur.errors import InvalidConfigurationException
+from conjur.errors import InvalidConfigurationException, ConfigurationMissingException
 
 
 class ConjurrcData:
@@ -43,6 +43,8 @@ class ConjurrcData:
                                     loaded_conjurrc['cert_file'])
         except KeyError as key_error:
             raise InvalidConfigurationException from key_error
+        except FileNotFoundError as not_found_err:
+            raise ConfigurationMissingException from not_found_err
 
     # pylint: disable=line-too-long
     def __repr__(self) -> str:

--- a/conjur/data_object/credentials_data.py
+++ b/conjur/data_object/credentials_data.py
@@ -6,14 +6,17 @@ CredentialsData module
 This module represents the DTO that holds credential data
 """
 
+
 # pylint: disable=too-few-public-methods
 class CredentialsData:
     """
     Used for setting user input data to login to Conjur
     """
+
+
     def __init__(self, machine: str = None, login: str = None, password: str = None):
         self.machine = machine
-        self.login = login
+        self.login = login # TODO rename to username
         self.password = password
 
     @classmethod
@@ -31,4 +34,5 @@ class CredentialsData:
         """
         Method for comparing resources by their values and not by reference
         """
-        return self.machine == other.machine and self.login == other.login and self.password == other.password
+        return self.machine == other.machine and self.login == other.login and self.password == \
+            other.password

--- a/test/test_unit_api.py
+++ b/test/test_unit_api.py
@@ -4,13 +4,18 @@ from datetime import datetime
 from unittest.mock import patch, MagicMock
 from urllib import parse
 
+from conjur.api.models import SslVerificationMetadata, SslVerificationMode
+from conjur.constants import DEFAULT_CERTIFICATE_FILE
 from conjur.data_object.create_token_data import CreateTokenData
+from conjur.data_object.conjurrc_data import ConjurrcData
 from conjur.errors import MissingRequiredParameterException
 from conjur.wrapper.http_wrapper import HttpVerb
 from conjur.api.endpoints import ConjurEndpoint
 
 from conjur.api import Api
 from conjur.resource import Resource
+from conjur.logic.credential_provider.file_credentials_provider import FileCredentialsProvider
+from conjur.data_object.credentials_data import CredentialsData
 
 MOCK_RESOURCE_LIST = [
     {
@@ -42,9 +47,19 @@ MOCK_POLICY_CHANGE_OBJECT = {
     "version": 4
 }
 
-
-MOCK_HOSTFACTORY_OBJECT = CreateTokenData(host_factory="some_host_factory", cidr="1.2.3.4,0.0.0.0", days=1)
+MOCK_HOSTFACTORY_OBJECT = CreateTokenData(host_factory="some_host_factory", cidr="1.2.3.4,0.0.0.0",
+                                          days=1)
 MOCK_HOSTFACTORY_WITHOUT_CIDR_OBJECT = CreateTokenData(host_factory="some_host_factory", days=1)
+MockCredentials = CredentialsData(login='myuser', password='mypass')
+
+
+def create_api(url='http://localhost', account='default',
+               ssl_verification_mode=SslVerificationMode.SELF_SIGN,
+               cert_path=DEFAULT_CERTIFICATE_FILE):
+    return Api(conjurrc_data=ConjurrcData(conjur_url=url, account=account, cert_file=cert_path),
+               ssl_verification_mode=ssl_verification_mode,
+               credentials_provider=FileCredentialsProvider())
+
 
 class ApiTest(unittest.TestCase):
     class MockClientResponse():
@@ -57,7 +72,6 @@ class ApiTest(unittest.TestCase):
     def verify_http_call(self, http_client, method, endpoint, *args,
                          ssl_verify=None, api_token='apitoken', auth=None, query=None,
                          account='default', headers={}, **kwargs):
-
 
         params = {
             'url': 'http://localhost',
@@ -84,10 +98,11 @@ class ApiTest(unittest.TestCase):
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
     def test_host_factory_create_token_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
+
         api.authenticate = mock_auth
 
         api.create_token(MOCK_HOSTFACTORY_OBJECT)
@@ -99,87 +114,89 @@ class ApiTest(unittest.TestCase):
                               query={},
                               api_token='apitoken',
                               headers={'Content-Type': 'application/x-www-form-urlencoded'},
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
-    def test_host_factory_create_token_with_no_cidr_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+    def test_host_factory_create_token_with_no_cidr_invokes_http_client_correctly(self,
+                                                                                  mock_http_client):
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
+
         api.authenticate = mock_auth
 
         api.create_token(MOCK_HOSTFACTORY_WITHOUT_CIDR_OBJECT)
-        MOCK_EXPECTED_HOSTFACTORY_PARAM = parse.urlencode(MOCK_HOSTFACTORY_WITHOUT_CIDR_OBJECT.to_dict(),
-                                                          doseq=True)
+        MOCK_EXPECTED_HOSTFACTORY_PARAM = parse.urlencode(
+            MOCK_HOSTFACTORY_WITHOUT_CIDR_OBJECT.to_dict(),
+            doseq=True)
 
         self.verify_http_call(mock_http_client, HttpVerb.POST, ConjurEndpoint.HOST_FACTORY_TOKENS,
                               MOCK_EXPECTED_HOSTFACTORY_PARAM,
                               query={},
                               api_token='apitoken',
                               headers={'Content-Type': 'application/x-www-form-urlencoded'},
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentials)
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
-    def test_new_client_delegates_ssl_verify_flag(self, mock_http_client):
-        Api(url='http://localhost', ssl_verify=True).login('myuser', 'mypass')
+    def test_new_client_delegates_ssl_verify_flag(self, mock_http_client, mock_creds):
+        create_api().login()
         self.verify_http_call(mock_http_client, HttpVerb.GET, ConjurEndpoint.LOGIN,
                               auth=('myuser', 'mypass'),
                               api_token=False,
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentials)
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
-    def test_new_client_overrides_ssl_verify_flag_with_ca_bundle_if_provided(self, mock_http_client):
-        Api(url='http://localhost', ssl_verify=True,
-            ca_bundle='cabundle').login('myuser', 'mypass')
+    def test_new_client_overrides_ssl_verify_flag_with_ca_bundle_if_provided(self,
+                                                                             mock_http_client,
+                                                                             mock_cres):
+        create_api().login()
         self.verify_http_call(mock_http_client, HttpVerb.GET, ConjurEndpoint.LOGIN,
                               auth=('myuser', 'mypass'),
                               api_token=False,
-                              ssl_verify='cabundle')
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentials)
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
-    def test_login_invokes_http_client_correctly(self, mock_http_client):
-        Api(url='http://localhost').login('myuser', 'mypass')
+    def test_login_invokes_http_client_correctly(self, mock_http_client, mock_creds):
+        create_api().login()
         self.verify_http_call(mock_http_client, HttpVerb.GET, ConjurEndpoint.LOGIN,
                               auth=('myuser', 'mypass'),
                               api_token=False,
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
-    def test_login_throws_error_when_username_not_provided(self):
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=CredentialsData("machine", login=""))
+    def test_login_throws_error_when_password_not_provided(self, mock_creds):
         with self.assertRaises(MissingRequiredParameterException):
-            Api(url='http://localhost').login(None, 'mypass')
+            create_api().login()
 
-    def test_login_throws_error_when_password_not_provided(self):
-        with self.assertRaises(MissingRequiredParameterException):
-            Api(url='http://localhost').login('myuser', None)
-
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentials)
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
-    def test_login_saves_login_id(self, _):
-        api = Api(url='http://localhost')
+    def test_login_saves_login_id(self, mock1, mock2):
+        api = create_api()
 
-        api.login('myuser', 'mypass')
+        api.login()
 
         self.assertEquals(api.login_id, 'myuser')
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
     def test_if_api_token_is_missing_fetch_a_new_one(self, mock_http_client):
-        api = Api(url='http://localhost')
+        api = create_api()
         api.authenticate = MagicMock(return_value='mytoken')
 
         self.assertEquals(api.api_token, 'mytoken')
         api.authenticate.assert_called_once_with()
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
-    def test_if_account_is_empty_throw_an_error(self, mock_http_client):
-        empty_values = [None, ""]
-        for empty_value in empty_values:
-            with self.subTest(account=empty_value):
-                with self.assertRaises(MissingRequiredParameterException):
-                    api = Api(url='http://localhost', account=empty_value)
-
-    @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
     def test_if_api_token_is_not_expired_dont_fetch_new_one(self, mock_http_client):
-        api = Api(url='http://localhost')
+        api = create_api()
         api.authenticate = MagicMock(return_value='mytoken')
 
         token = api.api_token
@@ -189,7 +206,7 @@ class ApiTest(unittest.TestCase):
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
     def test_if_api_token_is_expired_fetch_new_one(self, mock_http_client):
-        api = Api(url='http://localhost')
+        api = create_api()
         api.authenticate = MagicMock(return_value='mytoken')
 
         api.api_token
@@ -199,55 +216,11 @@ class ApiTest(unittest.TestCase):
 
         self.assertEquals(api.api_token, 'newtoken')
 
-    @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
-    def test_authenticate_invokes_http_client_correctly(self, mock_http_client):
-        Api(url='http://localhost', login_id='mylogin', api_key='apikey').authenticate()
-
-        self.verify_http_call(mock_http_client, HttpVerb.POST, ConjurEndpoint.AUTHENTICATE,
-                              'apikey',
-                              login='mylogin',
-                              api_token=False,
-                              ssl_verify=True)
-
-    def test_authenticate_throws_error_without_login_id_specified(self):
-        with self.assertRaises(MissingRequiredParameterException):
-            Api(url='http://localhost', api_key='apikey').authenticate()
-
-    def test_authenticate_throws_error_without_api_key_specified(self):
-        with self.assertRaises(MissingRequiredParameterException):
-            Api(url='http://localhost', login_id='mylogin').authenticate()
-
-    @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
-    def test_account_info_is_passed_down_to_http_call(self, mock_http_client):
-        Api(url='http://localhost',
-            account='myacct',
-            login_id='mylogin',
-            api_key='apikey').authenticate()
-
-        self.verify_http_call(mock_http_client, HttpVerb.POST, ConjurEndpoint.AUTHENTICATE,
-                              'apikey',
-                              headers={},
-                              login='mylogin',
-                              account='myacct',
-                              api_token=False,
-                              ssl_verify=True)
-
-    @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
-    def test_authenticate_passes_down_ssl_verify_param(self, mock_http_client):
-        Api(url='http://localhost', login_id='mylogin', api_key='apikey',
-            ssl_verify='verify').authenticate()
-
-        self.verify_http_call(mock_http_client, HttpVerb.POST, ConjurEndpoint.AUTHENTICATE,
-                              'apikey',
-                              api_token=False,
-                              login='mylogin',
-                              ssl_verify='verify')
-
     # Get variable
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
     def test_get_variable_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -260,11 +233,11 @@ class ApiTest(unittest.TestCase):
                               kind='variable',
                               identifier='myvar',
                               query={},
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
     def test_get_variable_with_version_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -277,12 +250,14 @@ class ApiTest(unittest.TestCase):
                               kind='variable',
                               identifier='myvar',
                               query={'version': '1'},
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
     def test_get_variable_passes_down_ssl_verify_param(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey',
-                  ssl_verify='verify')
+        api = create_api(ssl_verification_mode=SslVerificationMode.WITH_CA_BUNDLE,
+                         cert_path='verify')
+
+        # ssl_verify='verify')
 
         def mock_auth():
             return 'apitoken'
@@ -301,7 +276,7 @@ class ApiTest(unittest.TestCase):
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
     def test_set_variable_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -314,12 +289,11 @@ class ApiTest(unittest.TestCase):
                               'myvalue',
                               kind='variable',
                               identifier='myvar',
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse())
     def test_set_variable_passes_down_ssl_verify_param(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey',
-                  ssl_verify='verify')
+        api = create_api(cert_path='verify')
 
         def mock_auth():
             return 'apitoken'
@@ -338,7 +312,7 @@ class ApiTest(unittest.TestCase):
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse(text='{}'))
     def test_load_policy_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -354,12 +328,12 @@ class ApiTest(unittest.TestCase):
         self.verify_http_call(mock_http_client, HttpVerb.POST, ConjurEndpoint.POLICIES,
                               policy_data,
                               identifier='mypolicyname',
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint',
            return_value=MockClientResponse(text=json.dumps(MOCK_POLICY_CHANGE_OBJECT)))
     def test_load_policy_converts_returned_data_to_expected_objects(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -371,7 +345,10 @@ class ApiTest(unittest.TestCase):
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse(text='{}'))
     def test_load_policy_passes_down_ssl_verify_parameter(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey', ssl_verify='ssl_verify')
+        api = create_api(ssl_verification_mode=SslVerificationMode.WITH_CA_BUNDLE,
+                         cert_path="ssl_verify")
+
+        # ssl_verify='ssl_verify')
 
         def mock_auth():
             return 'apitoken'
@@ -393,7 +370,7 @@ class ApiTest(unittest.TestCase):
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse(text='{}'))
     def test_replace_policy_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -409,12 +386,12 @@ class ApiTest(unittest.TestCase):
         self.verify_http_call(mock_http_client, HttpVerb.PUT, ConjurEndpoint.POLICIES,
                               policy_data,
                               identifier='mypolicyname',
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint',
            return_value=MockClientResponse(text=json.dumps(MOCK_POLICY_CHANGE_OBJECT)))
     def test_replace_policy_converts_returned_data_to_expected_objects(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -426,7 +403,7 @@ class ApiTest(unittest.TestCase):
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse(text='{}'))
     def test_replace_policy_passes_down_ssl_verify_parameter(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey', ssl_verify='ssl_verify')
+        api = create_api(cert_path='ssl_verify')
 
         def mock_auth():
             return 'apitoken'
@@ -448,7 +425,7 @@ class ApiTest(unittest.TestCase):
 
     @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse(text='{}'))
     def test_update_policy_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -464,12 +441,12 @@ class ApiTest(unittest.TestCase):
         self.verify_http_call(mock_http_client, HttpVerb.PATCH, ConjurEndpoint.POLICIES,
                               policy_data,
                               identifier='mypolicyname',
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint',
            return_value=MockClientResponse(text=json.dumps(MOCK_POLICY_CHANGE_OBJECT)))
     def test_update_policy_converts_returned_data_to_expected_objects(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -479,31 +456,12 @@ class ApiTest(unittest.TestCase):
         output = api.update_policy_file('mypolicyname', self.POLICY_FILE)
         self.assertEqual(output, MOCK_POLICY_CHANGE_OBJECT)
 
-    @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse(text='{}'))
-    def test_update_policy_passes_down_ssl_verify_parameter(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey', ssl_verify='ssl_verify')
-
-        def mock_auth():
-            return 'apitoken'
-
-        api.authenticate = mock_auth
-
-        api.update_policy_file('mypolicyname', self.POLICY_FILE)
-
-        policy_data = None
-        with open(self.POLICY_FILE, 'r') as content_file:
-            policy_data = content_file.read()
-
-        self.verify_http_call(mock_http_client, HttpVerb.PATCH, ConjurEndpoint.POLICIES,
-                              policy_data,
-                              identifier='mypolicyname',
-                              ssl_verify='ssl_verify')
-
     # Get variables
 
-    @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse(content='{"foo": "a", "bar": "b"}'))
+    @patch('conjur.api.api.invoke_endpoint',
+           return_value=MockClientResponse(content='{"foo": "a", "bar": "b"}'))
     def test_get_variables_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -516,11 +474,12 @@ class ApiTest(unittest.TestCase):
                               query={
                                   'variable_ids': 'default:variable:myvar,default:variable:myvar2'
                               },
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
-    @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse(content=MOCK_BATCH_GET_RESPONSE))
+    @patch('conjur.api.api.invoke_endpoint',
+           return_value=MockClientResponse(content=MOCK_BATCH_GET_RESPONSE))
     def test_get_variables_converts_returned_data_to_expected_objects(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey', account='myaccount')
+        api = create_api(account='myaccount')
 
         def mock_auth():
             return 'apitoken'
@@ -534,9 +493,11 @@ class ApiTest(unittest.TestCase):
                              'bar': 'b',
                          })
 
-    @patch('conjur.api.api.invoke_endpoint', return_value=MockClientResponse(content='{"foo": "a", "bar": "b"}'))
+    @patch('conjur.api.api.invoke_endpoint',
+           return_value=MockClientResponse(content='{"foo": "a", "bar": "b"}'))
     def test_get_variables_passes_down_ssl_verify_parameter(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey', ssl_verify='sslverify')
+        api = create_api(ssl_verification_mode=SslVerificationMode.WITH_CA_BUNDLE,
+                         cert_path='sslverify')
 
         def mock_auth():
             return 'apitoken'
@@ -556,7 +517,7 @@ class ApiTest(unittest.TestCase):
     @patch('conjur.api.api.invoke_endpoint', \
            return_value=MockClientResponse(text=json.dumps(MOCK_RESOURCE_LIST)))
     def test_get_resources_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -567,12 +528,12 @@ class ApiTest(unittest.TestCase):
 
         self.verify_http_call(mock_http_client, HttpVerb.GET, ConjurEndpoint.RESOURCES,
                               query={},
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint', \
            return_value=MockClientResponse(text=json.dumps(MOCK_RESOURCE_LIST)))
     def test_get_resources_with_constraints_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -583,12 +544,12 @@ class ApiTest(unittest.TestCase):
 
         self.verify_http_call(mock_http_client, HttpVerb.GET, ConjurEndpoint.RESOURCES,
                               query={'limit': 1},
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint', \
            return_value=MockClientResponse(content=json.dumps({})))
     def test_whoami_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -598,12 +559,12 @@ class ApiTest(unittest.TestCase):
         api.whoami()
 
         self.verify_http_call(mock_http_client, HttpVerb.GET, ConjurEndpoint.WHOAMI,
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint', \
            return_value=MockClientResponse(content=json.dumps({})))
     def test_rotate_personal_api_key_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -615,12 +576,12 @@ class ApiTest(unittest.TestCase):
         self.verify_http_call(mock_http_client, HttpVerb.PUT, ConjurEndpoint.ROTATE_API_KEY,
                               api_token='',
                               auth=('mylogin', 'somepass'),
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint', \
            return_value=MockClientResponse(content=json.dumps({})))
     def test_rotate_other_api_key_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -631,12 +592,13 @@ class ApiTest(unittest.TestCase):
 
         self.verify_http_call(mock_http_client, HttpVerb.PUT, ConjurEndpoint.ROTATE_API_KEY,
                               query={'role': 'user:somename'},
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)
 
     @patch('conjur.api.api.invoke_endpoint', \
            return_value=MockClientResponse(content=json.dumps({})))
-    def test_rotate_other_api_key_can_raise_exception_when_resource_is_invalid(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+    def test_rotate_other_api_key_can_raise_exception_when_resource_is_invalid(self,
+                                                                               mock_http_client):
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -648,7 +610,7 @@ class ApiTest(unittest.TestCase):
     @patch('conjur.api.api.invoke_endpoint', \
            return_value=MockClientResponse(content=json.dumps({})))
     def test_change_password_invokes_http_client_correctly(self, mock_http_client):
-        api = Api(url='http://localhost', login_id='mylogin', api_key='apikey')
+        api = create_api()
 
         def mock_auth():
             return 'apitoken'
@@ -661,4 +623,4 @@ class ApiTest(unittest.TestCase):
                               "somenewpass",
                               api_token='',
                               auth=('someloggedinuser', 'somecurrentpass'),
-                              ssl_verify=True)
+                              ssl_verify=DEFAULT_CERTIFICATE_FILE)

--- a/test/test_unit_client.py
+++ b/test/test_unit_client.py
@@ -4,56 +4,51 @@ import unittest
 import uuid
 from unittest.mock import patch
 
-from conjur.api.client import ConfigurationMissingException, Client
+from conjur.api.client import  Client
+from conjur.api.models import SslVerificationMetadata, SslVerificationMode
 
 from conjur.data_object import CredentialsData
 from conjur.data_object.create_token_data import CreateTokenData
-from conjur.errors import CertificateVerificationException
+from conjur.errors import CertificateVerificationException, ConfigurationMissingException
+from conjur.data_object.conjurrc_data import ConjurrcData
+from conjur.logic.credential_provider import FileCredentialsProvider
 
-MockCredentials = CredentialsData(login='apiconfigloginid', password='apiconfigapikey')
+# region api settings
+MockCredentialsApi = CredentialsData(login='apiconfigloginid', password='apiconfigapikey')
+MockConjurrcApi = ConjurrcData(conjur_url="apiconfigurl",
+                               account="apiconfigaccount",
+                               cert_file="apiconfigcabundle")
+MockSslVerificationMetaDataApi = SslVerificationMetadata(
+    mode=SslVerificationMode.WITH_CA_BUNDLE,
+    ca_cert_path="apiconfigcabundle")
+# endregion
 
-# ApiConfig mocking class
-class MockApiConfig(object):
-    CONFIG = {
-        'key1': 'value1',
-        'key2': 'value2',
+# region regular settings
+MockCredentials = CredentialsData(login='mylogin', password='someapikey')
+MockConjurrc = ConjurrcData(conjur_url="http://foo",
+                            account="myacct",
+                            cert_file=None)
+MockSslVerificationMetaData = SslVerificationMetadata(
+    mode=SslVerificationMode.WITH_TRUST_STORE)
 
-        'url': 'apiconfigurl',
-        'account': 'apiconfigaccount',
-        'ca_bundle': 'apiconfigcabundle',
-    }
 
-    def __iter__(self):
-        return iter(self.CONFIG.items())
+# endregion
 
-# ApiConfig mocking class
-class EmptyMockApiConfig(object):
-    def __init__(self):
-        raise ConfigurationMissingException
-
-# ApiConfig mocking class
-class MockApiConfigNoCert(object):
-    CONFIG = {
-        'key1': 'value1',
-        'key2': 'value2',
-
-        'url': 'apiconfigurl',
-        'account': 'apiconfigaccount',
-        'ca_bundle': '',
-    }
-
-    def __iter__(self):
-        return iter(self.CONFIG.items())
+def create_client(api_format=False, debug=True):
+    if api_format:
+        return Client(conjurrc_data=MockConjurrcApi,
+                      ssl_verification_mode=MockSslVerificationMetaDataApi.mode,
+                      credentials_provider=FileCredentialsProvider(),
+                      debug=debug)
+    return Client(conjurrc_data=MockConjurrc,
+                  ssl_verification_mode=MockSslVerificationMetaData.mode,
+                  credentials_provider=FileCredentialsProvider(),
+                  debug=debug)
 
 
 class MOCK_RESOURCE:
     type = "sometype"
     name = "somename"
-
-
-class MissingMockApiConfig(object):
-    def __init__(self):
-        raise FileNotFoundError("oops!")
 
 
 class ConfigErrorTest(unittest.TestCase):
@@ -66,421 +61,313 @@ class ClientTest(unittest.TestCase):
     # To run properly, we need to configure the loaded conjurrc
 
     ### Init configuration tests ###
-    @patch('conjur.api.client.ApiConfig', new=MissingMockApiConfig)
-    def test_client_throws_error_when_no_config(self):
-        with self.assertRaises(FileNotFoundError):
-            Client()
-
-    @patch('conjur.api.client.ApiConfig', new=EmptyMockApiConfig)
-    def test_client_throws_error_with_empty_config(self):
-        with self.assertRaises(ConfigurationMissingException):
-            Client()
-
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentials)
     @patch('conjur.api.client.Api')
     @patch('logging.basicConfig')
-    def test_client_initializes_logging(self, mock_logging, mock_api):
-        Client(url='http://myurl', account='myacct', login_id='mylogin',
-               password='mypass')
+    def test_client_initializes_logging(self, mock_logging, mock_api, mock_creds, mock):
+        create_client(debug=False)
 
-        mock_logging.assert_called_once_with(format=Client.LOGGING_FORMAT_WARNING, level=logging.WARNING)
+        mock_logging.assert_called_once_with(format=Client.LOGGING_FORMAT_WARNING,
+                                             level=logging.WARNING)
 
     @patch('conjur.api.client.Api')
     @patch('logging.basicConfig')
     def test_client_increases_logging_with_debug_flag(self, mock_logging, mock_api):
-        Client(url='http://myurl', account='myacct', login_id='mylogin',
-               password='mypass', debug=True)
+        create_client()
 
         mock_logging.assert_called_once_with(format=Client.LOGGING_FORMAT, level=logging.DEBUG)
 
-    @patch('conjur.api.client.Api')
-    def test_client_passes_init_config_params_to_api_initializer(self, mock_api_instance):
-        Client(url='http://myurl', account='myacct', login_id='mylogin',
-               password='mypass', ca_bundle="mybundle", ssl_verify=False)
-
-        mock_api_instance.assert_called_with(
-            account='myacct',
-            ca_bundle='mybundle',
-            http_debug=False,
-            ssl_verify=False,
-            url='http://myurl',
-        )
-
     @patch('conjur.api.Api')
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', side_effect=netrc.NetrcParseError(''))
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           side_effect=netrc.NetrcParseError(''))
     def test_client_can_raise_netrc_exception_error(self, mock_cred, mock_api_instance):
         with self.assertRaises(Exception):
-            Client(url='https://myurl', account='myacct', login_id='mylogin', ca_bundle="mybundle", ssl_verify=False)
-
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfigNoCert())
-    def test_client_can_raise_incomplete_operation_error_if_ssl_modes_are_conflicting(self, mock_config):
-        with self.assertRaises(CertificateVerificationException):
-            Client(ssl_verify=True)
-
-    @patch('conjur.api.client.Api')
-    def test_client_passes_default_account_to_api_initializer_if_none_is_provided(self, mock_api_instance):
-        Client(url='http://myurl', login_id='mylogin', password='mypass',
-               ca_bundle="mybundle")
-
-        mock_api_instance.assert_called_with(
-            account='default',
-            ca_bundle='mybundle',
-            http_debug=False,
-            ssl_verify=True,
-            url='http://myurl',
-        )
-
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.Api')
-    def test_client_performs_password_api_login_if_password_is_provided(self, mock_api_instance, mock_accessible):
-        Client(url='http://foo', account='myacct', login_id='mylogin',
-               password='mypass')
-
-        mock_api_instance.return_value.login.assert_called_once_with('mylogin', 'mypass')
-
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.Api')
-    def test_client_initializes_client_with_api_key_if_its_provided(self, mock_api_instance, mock_accessible):
-        Client(url='http://foo', account='myacct', login_id='mylogin',
-               api_key='someapikey')
-
-        mock_api_instance.assert_called_with(
-            account='myacct',
-            api_key='someapikey',
-            ca_bundle=None,
-            http_debug=False,
-            login_id='mylogin',
-            ssl_verify=True,
-            url='http://foo',
-        )
-
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
-    @patch('conjur.api.client.Api')
-    def test_client_performs_no_api_login_if_password_is_not_provided(self, mock_api_instance, mock_creds,
-                                                                      mock_api_config, mock_accessible):
-        Client(url='http://foo', account='myacct', login_id='mylogin')
-
-        mock_api_instance.return_value.login.assert_not_called()
-
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
-    @patch('conjur.api.client.Api')
-    def test_client_passes_config_from_apiconfig_if_url_is_not_provided(self, mock_api_instance, mock_creds,
-                                                                        mock_api_config):
-        Client(account='myacct', login_id='mylogin', password="mypass")
-
-        mock_api_instance.assert_called_with(
-            account='myacct',
-            ca_bundle='apiconfigcabundle',
-            http_debug=False,
-            key1='value1',
-            key2='value2',
-            ssl_verify=True,
-            url='apiconfigurl',
-        )
-
-    @patch('conjur.api.client.Api')
-    def test_client_does_not_pass_config_from_apiconfig_if_only_account_is_empty(
-            self, mock_api_instance):
-        Client(url='http://foo', login_id='mylogin', password="mypass")
-
-        mock_api_instance.assert_called_with(
-            account='default',
-            ca_bundle=None,
-            http_debug=False,
-            ssl_verify=True,
-            url='http://foo',
-        )
-
-        mock_api_instance.return_value.login.assert_called_once_with('mylogin', 'mypass')
-
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
-    @patch('conjur.api.client.Api')
-    def test_client_passes_config_from_apiconfig_if_login_id_is_not_provided(self, mock_api_instance, mock_creds,
-                                                                             mock_api_config):
-        Client(url='http://foo', account='myacct', password="mypass")
-
-        mock_api_instance.assert_called_with(
-            account='myacct',
-            ca_bundle='apiconfigcabundle',
-            http_debug=False,
-            key1='value1',
-            key2='value2',
-            ssl_verify=True,
-            url='http://foo',
-        )
-
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
-    @patch('conjur.api.client.Api')
-    def test_client_passes_config_from_apiconfig_if_password_is_not_provided(self, mock_api_instance, mock_creds,
-                                                                             mock_api_config, mock_accessible):
-        Client(url='http://foo', account='myacct', login_id='mylogin')
-
-        mock_api_instance.assert_called_with(
-            account='myacct',
-            api_key='apiconfigapikey',
-            ca_bundle='apiconfigcabundle',
-            http_debug=False,
-            key1='value1',
-            key2='value2',
-            login_id='apiconfigloginid',
-            ssl_verify=True,
-            url='http://foo',
-        )
-
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
-    @patch('conjur.api.client.Api')
-    def test_client_overrides_apiconfig_value_with_explicitly_provided_ones(self, mock_api_instance, mock_creds,
-                                                                            mock_api_config, mock_accessible):
-        Client(url='http://foo', account='myacct', login_id='mylogin',
-               ca_bundle='mybundle')
-
-        mock_api_instance.assert_called_with(
-            account='myacct',
-            api_key='apiconfigapikey',
-            ca_bundle='mybundle',
-            http_debug=False,
-            key1='value1',
-            key2='value2',
-            login_id='apiconfigloginid',
-            ssl_verify=True,
-            url='http://foo',
-        )
-
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
-    @patch('conjur.api.client.Api')
-    def test_client_does_not_override_apiconfig_values_with_empty_values(self, mock_api_instance, mock_creds,
-                                                                         mock_api_config, mock_accessible):
-        Client(url=None, account=None, login_id=None, ca_bundle=None)
-
-        mock_api_instance.assert_called_with(
-            account='apiconfigaccount',
-            api_key='apiconfigapikey',
-            ca_bundle='apiconfigcabundle',
-            http_debug=False,
-            key1='value1',
-            key2='value2',
-            login_id='apiconfigloginid',
-            ssl_verify=True,
-            url='apiconfigurl',
-        )
+            create_client().list()
 
     ### API passthrough tests ###
 
-
     @patch('conjur.api.client.Api')
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('logging.basicConfig')
     def test_client_increases_logging_with_debug_flag(self, mock_logging, mock_creds, mock_api):
-        Client(url='http://myurl', account='myacct', login_id='mylogin',
-               password='mypass', debug=True)
+        Client(conjurrc_data=MockConjurrcApi,
+               ssl_verification_mode=MockSslVerificationMetaDataApi.mode,
+               credentials_provider=FileCredentialsProvider(),
+               debug=True)
 
         mock_logging.assert_called_once_with(format=Client.LOGGING_FORMAT, level=logging.DEBUG)
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_get_variable_params(self, mock_api_instance, mock_creds,
-                                                           mock_api_config, mock_accessible):
-        Client().get('variable_id')
+    def test_client_passes_through_api_get_variable_params(
+            self, mock_api_instance, mock_creds, mock_conjurrc, mock_accessible):
+        create_client().get('variable_id')
 
         mock_api_instance.return_value.get_variable.assert_called_once_with('variable_id', None)
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_returns_get_variable_result(self, mock_api_instance, mock_creds,
-                                                mock_api_config, mock_accessible):
+    def test_client_returns_get_variable_result(
+            self, mock_api_instance, mock_creds, mock_conjurrc,
+            mock_api_config, mock_accessible):
         variable_value = uuid.uuid4().hex
         mock_api_instance.return_value.get_variable.return_value = variable_value
 
-        return_value = Client().get('variable_id')
+        return_value = create_client().get('variable_id')
         self.assertEquals(return_value, variable_value)
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_get_many_variables_params(self, mock_api_instance, mock_creds,
-                                                                 mock_api_config, mock_accessible):
-        Client().get_many('variable_id', 'variable_id2')
+    def test_client_passes_through_api_get_many_variables_params(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().get_many('variable_id', 'variable_id2')
 
         mock_api_instance.return_value.get_variables.assert_called_once_with(
             'variable_id',
             'variable_id2'
         )
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_returns_get_variables_result(self, mock_api_instance, mock_creds,
-                                                 mock_api_config, mock_accessible):
+    def test_client_returns_get_variables_result(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
         variable_values = uuid.uuid4().hex
         mock_api_instance.return_value.get_variables.return_value = variable_values
 
-        return_value = Client().get_many('variable_id', 'variable_id2')
+        return_value = create_client().get_many('variable_id', 'variable_id2')
         self.assertEquals(return_value, variable_values)
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_set_variable_params(self, mock_api_instance, mock_creds,
-                                                           mock_api_config, mock_accessible):
-        Client().set('variable_id', 'variable_value')
+    def test_client_passes_through_api_set_variable_params(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().set('variable_id', 'variable_value')
 
         mock_api_instance.return_value.set_variable.assert_called_once_with(
             'variable_id',
             'variable_value',
         )
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_load_policy_params(self, mock_api_instance, mock_creds,
-                                                          mock_api_config, mock_accessible):
-        Client().load_policy_file('name', 'policy')
+    def test_client_passes_through_api_load_policy_params(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().load_policy_file('name', 'policy')
 
         mock_api_instance.return_value.load_policy_file.assert_called_once_with(
             'name',
             'policy',
         )
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_returns_load_policy_result(self, mock_api_instance, mock_creds,
-                                               mock_api_config, mock_accessible):
+    def test_client_returns_load_policy_result(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
         load_policy_result = uuid.uuid4().hex
         mock_api_instance.return_value.load_policy_file.return_value = load_policy_result
 
-        return_value = Client().load_policy_file('name', 'policy')
+        return_value = create_client().load_policy_file('name', 'policy')
         self.assertEquals(return_value, load_policy_result)
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_replace_policy_params(self, mock_api_instance, mock_creds,
-                                                             mock_api_config, mock_accessible):
-        Client().replace_policy_file('name', 'policy')
+    def test_client_passes_through_api_replace_policy_params(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().replace_policy_file('name', 'policy')
 
         mock_api_instance.return_value.replace_policy_file.assert_called_once_with(
             'name',
             'policy'
         )
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
     @patch('conjur.api.client.Api')
-    def test_client_returns_replace_policy_result(self, mock_api_instance,
-                                                  mock_api_config, mock_accessible):
-        with patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials):
+    def test_client_returns_replace_policy_result(
+            self, mock_api_instance,
+            mock_api_config, mock_accessible):
+        with patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+                   return_value=MockCredentialsApi):
             replace_policy_result = uuid.uuid4().hex
             mock_api_instance.return_value.replace_policy_file.return_value = replace_policy_result
 
-            return_value = Client().replace_policy_file('name', 'policy')
+            return_value = create_client().replace_policy_file('name', 'policy')
             self.assertEquals(return_value, replace_policy_result)
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_update_policy_params(self, mock_api_instance, mock_creds,
-                                                            mock_api_config, mock_accessible):
-        Client().update_policy_file('name', 'policy')
+    def test_client_passes_through_api_update_policy_params(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().update_policy_file('name', 'policy')
 
         mock_api_instance.return_value.update_policy_file.assert_called_once_with(
             'name',
             'policy'
         )
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_returns_update_policy_result(self, mock_api_instance, mock_creds,
-                                                 mock_api_config, mock_accessible):
+    def test_client_returns_update_policy_result(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
         update_policy_result = uuid.uuid4().hex
         mock_api_instance.return_value.update_policy_file.return_value = update_policy_result
 
-        return_value = Client().update_policy_file('name', 'policy')
+        return_value = create_client().update_policy_file('name', 'policy')
         self.assertEquals(return_value, update_policy_result)
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_resource_list_method(self, mock_api_instance, mock_creds,
-                                                        mock_api_config, mock_accessible):
-        Client().list({})
+    def test_client_passes_through_resource_list_method(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().list({})
 
         mock_api_instance.return_value.resources_list.assert_called_once_with({})
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_whoami_method(self, mock_api_instance, mock_creds,
-                                                 mock_api_config, mock_accessible):
-        Client().whoami()
+    def test_client_passes_through_whoami_method(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().whoami()
 
         mock_api_instance.return_value.whoami.assert_called_once_with()
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_rotate_other_api_key_params(self, mock_api_instance, mock_creds,
-                                                                   mock_api_config, mock_accessible):
-        Client().rotate_other_api_key(MOCK_RESOURCE)
+    def test_client_passes_through_api_rotate_other_api_key_params(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().rotate_other_api_key(MOCK_RESOURCE)
 
         mock_api_instance.return_value.rotate_other_api_key.assert_called_once_with(MOCK_RESOURCE)
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_rotate_personal_api_key_params(self, mock_api_instance, mock_creds,
-                                                                      mock_api_config, mock_accessible):
-        Client().rotate_personal_api_key("someloggedinuser", "somecurrentpassword")
+    def test_client_passes_through_api_rotate_personal_api_key_params(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().rotate_personal_api_key("someloggedinuser", "somecurrentpassword")
 
-        mock_api_instance.return_value.rotate_personal_api_key.assert_called_once_with("someloggedinuser",
-                                                                                       "somecurrentpassword")
+        mock_api_instance.return_value.rotate_personal_api_key.assert_called_once_with(
+            "someloggedinuser",
+            "somecurrentpassword")
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_change_password_params(self, mock_api_instance, mock_creds,
-                                                              mock_api_config, mock_accessible):
-        Client().change_personal_password("someloggedinuser", "somecurrentpassword", "somenewpassword")
+    def test_client_passes_through_api_change_password_params(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
+        create_client().change_personal_password("someloggedinuser", "somecurrentpassword",
+                                                 "somenewpassword")
 
-        mock_api_instance.return_value.change_personal_password.assert_called_once_with("someloggedinuser",
-                                                                                        "somecurrentpassword",
-                                                                                        "somenewpassword")
+        mock_api_instance.return_value.change_personal_password.assert_called_once_with(
+            "someloggedinuser",
+            "somecurrentpassword",
+            "somenewpassword")
 
-    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
-    @patch('conjur.api.client.ApiConfig', return_value=MockApiConfig())
-    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load', return_value=MockCredentials)
+    @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible',
+           return_value=False)
+    @patch('conjur.data_object.conjurrc_data.ConjurrcData.load_from_file',
+           return_value=MockConjurrcApi)
+    @patch('conjur.logic.credential_provider.FileCredentialsProvider.load',
+           return_value=MockCredentialsApi)
     @patch('conjur.api.client.Api')
-    def test_client_passes_through_api_host_factory_token_create_params(self, mock_api_instance, mock_creds,
-                                                                        mock_api_config, mock_accessible):
+    def test_client_passes_through_api_host_factory_token_create_params(
+            self, mock_api_instance, mock_creds,
+            mock_api_config, mock_accessible):
         mock_create_token_data = CreateTokenData(host_factory="some_hostfactory_id", days=1)
-        Client().create_token(mock_create_token_data)
+        create_client().create_token(mock_create_token_data)
 
         mock_api_instance.return_value.create_token.assert_called_once_with(mock_create_token_data)
-

--- a/test/test_unit_utils.py
+++ b/test/test_unit_utils.py
@@ -1,0 +1,31 @@
+import unittest
+
+from conjur.api.models import SslVerificationMode
+from conjur.constants import DEFAULT_CERTIFICATE_FILE
+from conjur.util import util_functions as utils
+from conjur.data_object import ConjurrcData
+
+
+class UserInputDataTest(unittest.TestCase):
+
+    def test_get_ssl_verification_meta_data_from_conjurrc_no_ssl(self):
+        data = ConjurrcData(conjur_url="https://foo.com", account="some_account", cert_file="cert")
+        res = utils.get_ssl_verification_meta_data_from_conjurrc(False, data)
+        self.assertEquals(res.mode, SslVerificationMode.NO_SSL)
+
+    def test_get_ssl_verification_meta_data_from_conjurrc_self_sign(self):
+        data = ConjurrcData(conjur_url="https://foo.com", account="some_account",
+                            cert_file=DEFAULT_CERTIFICATE_FILE)
+        res = utils.get_ssl_verification_meta_data_from_conjurrc(True, data)
+        self.assertEquals(res.mode, SslVerificationMode.SELF_SIGN)
+
+    def test_get_ssl_verification_meta_data_from_conjurrc_trust_store(self):
+        data = ConjurrcData(conjur_url="https://foo.com", account="some_account", cert_file="")
+        res = utils.get_ssl_verification_meta_data_from_conjurrc(True, data)
+        self.assertEquals(res.mode, SslVerificationMode.WITH_TRUST_STORE)
+
+    def test_get_ssl_verification_meta_data_from_conjurrc_ca_bundle(self):
+        data = ConjurrcData(conjur_url="https://foo.com", account="some_account",
+                            cert_file="cert")
+        res = utils.get_ssl_verification_meta_data_from_conjurrc(True, data)
+        self.assertEquals(res.mode, SslVerificationMode.WITH_CA_BUNDLE)


### PR DESCRIPTION
### Desired Outcome

Client will be initialized with less parameters and specific, with a SslVerificationMetaData struct that holds the sslVerification data. This struct should be drilled down to the http_wrapper.

### Implemented Changes

- Added SslVerificationMetaData struct
- Changed constructor in both client and api
- Added functionality to create client from conjurrc (instead of the old way which was done inside the class constructor)

### Connected Issue/Story

Resolves [ONYX-14370](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14370)

### Definition of Done
* Client could accept ssl_verification_meta_data object and all functionality will work

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
