### PR TITLE
Extend linting check line length to 120

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[FORMAT]
+max-line-length=120

--- a/conjur/wrapper/http_wrapper.py
+++ b/conjur/wrapper/http_wrapper.py
@@ -18,8 +18,7 @@ from aiohttp import BasicAuth, ClientError, ClientResponseError, ClientSSLError,
 import async_timeout
 import urllib3
 
-from conjur.errors import CertificateHostnameMismatchException, HttpSslError, HttpError, \
-    HttpStatusError
+from conjur.errors import CertificateHostnameMismatchException, HttpSslError, HttpError,HttpStatusError
 from conjur.api.endpoints import ConjurEndpoint
 from conjur.wrapper.http_response import HttpResponse
 


### PR DESCRIPTION
### Desired Outcome

pipeline linting stage will now require less then 120 chars in line instead of 100

### Implemented Changes

- Added pylintrc file with the configuration
- Extended lien 21 in http_wrapper.py to test pipeline
