### PR TITLE
Fix flaky hostfactory integration tests

### DIFF
--- a/test/host_factory/test_integration_hostfactory.py
+++ b/test/host_factory/test_integration_hostfactory.py
@@ -31,31 +31,6 @@ class CliIntegrationTestHostFactory(IntegrationTestCaseBase):  # pragma: no cove
     def __init__(self, test_name, client_params=None, environment_params=None):
         super(CliIntegrationTestHostFactory, self).__init__(test_name, client_params, environment_params)
 
-    @staticmethod
-    def time_iso_format_exclude_seconds(duration: timedelta):
-        return ''.join((datetime.utcnow().replace(microsecond=0) + duration).isoformat()[:-2])
-
-    @staticmethod
-    def one_hour_from_now():
-        return CliIntegrationTestHostFactory.time_iso_format_exclude_seconds(timedelta(hours=1))
-
-    @staticmethod
-    def token_response_regex(cidr: str):
-        return '\[\n    {\n        "cidr": \[\n' \
-               f'            "{cidr}"\n' \
-               '        \],\n        "expiration": "' \
-               f'{CliIntegrationTestHostFactory.one_hour_from_now()}\d\dZ",\n        "token": ".*"\n' \
-               '    }\n\]\n'
-
-    @staticmethod
-    def token_response_empty_cidr_regex(duration: str):
-        return '\[\n    {\n' \
-               '        "cidr": \[],\n' \
-               f'        "expiration": "' \
-               f'{duration}\d\dZ",\n        ' \
-               '"token": ".*"\n' \
-               '    }\n]\n'
-
     def setUp(self):
         self.setup_cli_params({})
         # Used to configure the CLI and login to run tests


### PR DESCRIPTION
In hostfactory tests, instead of asserting expiration as regex, assert
it explicitly as time object and allow up to 10 seconds difference from
expected result.

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
