### PR TITLE
Add init flag to enable netrc credential storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Support authn-ldap
   [cyberark/cyberark-conjur-cli#411](https://github.com/cyberark/cyberark-conjur-cli/pull/411)
-- Add netrc credential storage mode as `init` option via `--use-netrc`
+- Add netrc credential storage mode as `init` option via `--force-netrc`
   [cyberark/cyberark-conjur-cli#414](https://github.com/cyberark/cyberark-conjur-cli/pull/414)
 
 ### Fixed

--- a/conjur/argument_parser/_init_parser.py
+++ b/conjur/argument_parser/_init_parser.py
@@ -68,10 +68,10 @@ class InitParser:
                                        'to the cli in case it is not already trusted by this machine')
         init_options.add_argument('-s', '--self-signed', action='store_true', dest='is_self_signed',
                                   help='Optional- state if you want to work with self-signed certificate')
-        init_options.add_argument('--use-netrc',
-                                  action='store_true', dest='use_netrc',
-                                  help='Optional- use file-based credential storage in $HOME/.netrc rather '
-                                       'than OS-native keystore (for compatibility with Summon)')
+        init_options.add_argument('--force-netrc',
+                                  action='store_true', dest='force_netrc',
+                                  help='Optional- force the CLI to use a file-based credential storage in'
+                                       '$HOME/.netrc rather than OS-native keystore (for compatibility with Summon)')
         init_options.add_argument('--force',
                                   action='store_true',
                                   dest='force', help='Optional- force overwrite of existing files')

--- a/conjur/cli.py
+++ b/conjur/cli.py
@@ -76,9 +76,9 @@ class Cli:
 
         # There may be a better way to do this. Currently we have to
         # re-initialize the credential store once the CLI args become available
-        if 'use_netrc' not in args or args.use_netrc is False:
-            args.use_netrc = None
-        self.credential_provider = CredentialStoreFactory.create_credential_store(args.use_netrc)
+        if 'force_netrc' not in args or args.force_netrc is False:
+            args.force_netrc = None
+        self.credential_provider = CredentialStoreFactory.create_credential_store(args.force_netrc)
 
         # pylint: disable=broad-except
         try:
@@ -125,7 +125,7 @@ class Cli:
                                           args.authn_type, args.service_id,
                                           args.certificate, args.force,
                                           args.ssl_verify, args.is_self_signed,
-                                          args.use_netrc)
+                                          args.force_netrc)
             # A successful exit is required to prevent the initialization of
             # the Client because the init command does not require the Client
             # The below message when a user explicitly requested to init

--- a/conjur/cli_actions.py
+++ b/conjur/cli_actions.py
@@ -29,6 +29,7 @@ from conjur.data_object import ConjurrcData, UserInputData, HostResourceData, Li
     PolicyData
 from conjur.util.ssl_utils import SSLClient
 from conjur.util import init_utils, util_functions
+from conjur.constants import DEFAULT_NETRC_FILE
 
 
 # pylint: disable=raise-missing-from
@@ -37,7 +38,7 @@ def handle_init_logic(
         authn_type: str = None, service_id: str = None,
         cert: str = None, force: bool = None,
         ssl_verify=None, is_self_signed: bool = False,
-        use_netrc: bool = None):
+        force_netrc: str = None):
     """
     Method that wraps the init call logic
     Initializes the client, creating the .conjurrc file
@@ -70,13 +71,15 @@ def handle_init_logic(
     if service_id and not authn_type:
         authn_type = "ldap"
 
+    netrc_path = DEFAULT_NETRC_FILE if force_netrc else None
+
     # TODO conjurrcData creation should move to controller
     conjurrc_data = ConjurrcData(conjur_url=url,
                                  account=account,
                                  cert_file=cert,
                                  authn_type=authn_type,
                                  service_id=service_id,
-                                 use_netrc=use_netrc)
+                                 netrc_path=netrc_path)
 
     init_logic = InitLogic(ssl_service)
     input_controller = InitController(conjurrc_data=conjurrc_data,

--- a/conjur/data_object/conjurrc_data.py
+++ b/conjur/data_object/conjurrc_data.py
@@ -33,13 +33,13 @@ class ConjurrcData:
 
     # pylint: disable=too-many-arguments
     def __init__(self, conjur_url: str = None, account: str = None, cert_file: str = None,
-                 authn_type: str = None, service_id: str = None, use_netrc: bool = None):
+                 authn_type: str = None, service_id: str = None, netrc_path: str = None):
         self.conjur_url = conjur_url
         self.conjur_account = account
         self.cert_file = cert_file
         self.authn_type = ConjurrcData._parse_authn_type(authn_type)
         self.service_id = service_id
-        self.use_netrc = use_netrc
+        self.netrc_path = netrc_path
 
     # pylint: disable=unspecified-encoding
     @classmethod
@@ -59,7 +59,7 @@ class ConjurrcData:
                                     loaded_conjurrc['cert_file'],
                                     loaded_conjurrc.get('authn_type'),
                                     loaded_conjurrc.get('service_id'),
-                                    loaded_conjurrc.get('use_netrc'))
+                                    loaded_conjurrc.get('netrc_path'))
         except KeyError as key_error:
             raise InvalidConfigurationException from key_error
         except FileNotFoundError as not_found_err:
@@ -77,7 +77,7 @@ class ConjurrcData:
                 'cert_file': self.cert_file,
                 'authn_type': str(self.authn_type),
                 'service_id': self.service_id,
-                'use_netrc': self.use_netrc
+                'netrc_path': self.netrc_path
             }
             out = f"---\n{yaml_dump(data)}"
             config_fp.write(out)

--- a/conjur/logic/credential_provider/credential_store_factory.py
+++ b/conjur/logic/credential_provider/credential_store_factory.py
@@ -26,14 +26,14 @@ class CredentialStoreFactory:
     """
 
     @classmethod
-    def create_credential_store(cls, use_netrc_flag: bool = None) -> CredentialsProviderInterface:
+    def create_credential_store(cls, force_netrc_flag: bool = None) -> CredentialsProviderInterface:
         """
         Factory method for determining which store to use
         """
         keyring_name = KeystoreWrapper.get_keyring_name()
-        use_netrc = use_netrc_flag or util_functions.get_netrc_flag_from_conjurrc()
+        use_netrc = force_netrc_flag or util_functions.get_netrc_path_from_conjurrc()
 
-        if keyring_name in SUPPORTED_BACKENDS and use_netrc is False:
+        if keyring_name in SUPPORTED_BACKENDS and use_netrc is None:
             if KeystoreWrapper.is_keyring_accessible():
                 return KeystoreCredentialsProvider()
 

--- a/conjur/logic/credential_provider/file_credentials_provider.py
+++ b/conjur/logic/credential_provider/file_credentials_provider.py
@@ -146,7 +146,7 @@ class FileCredentialsProvider(CredentialsProviderInterface):
         """
 
         if cls.FIRST_TIME_LOG_INSECURE_STORE_WARNING:
-            if use_netrc is False:
+            if use_netrc is None:
                 # pylint: disable=logging-fstring-interpolation
                 logging.warning("No supported keystore found! Saving credentials in "
                                 f"plaintext in '{DEFAULT_NETRC_FILE}'. Make sure to logoff "

--- a/conjur/util/util_functions.py
+++ b/conjur/util/util_functions.py
@@ -124,9 +124,9 @@ def get_ssl_verification_meta_data_from_conjurrc(ssl_verify: bool,
         return SslVerificationMetadata(SslVerificationMode.CA_BUNDLE, cert_path)
     return SslVerificationMetadata(SslVerificationMode.SELF_SIGN, cert_path)
 
-def get_netrc_flag_from_conjurrc(conjur_data: ConjurrcData = None) -> bool:
+def get_netrc_path_from_conjurrc(conjur_data: ConjurrcData = None) -> str:
     """
-    Determine use_netrc from conjurrc file (if it exists)
+    Determine netrc_path from conjurrc file (if it exists)
     Ignore any conjurrc errors here since this gets called
     before the CLI's main exception handling block
     """
@@ -136,6 +136,6 @@ def get_netrc_flag_from_conjurrc(conjur_data: ConjurrcData = None) -> bool:
         except InvalidConfigurationException:
             pass
 
-    if hasattr(conjur_data, "use_netrc") and conjur_data.use_netrc is True:
-        return True
-    return False
+    if hasattr(conjur_data, "netrc_path") and conjur_data.netrc_path is not None:
+        return conjur_data.netrc_path
+    return None

--- a/test/test_integration_configurations.py
+++ b/test/test_integration_configurations.py
@@ -17,7 +17,7 @@ from test.util.test_infrastructure import integration_test
 from test.util.test_runners.integration_test_case import IntegrationTestCaseBase
 from test.util import test_helpers as utils
 
-from conjur.constants import DEFAULT_CONFIG_FILE, DEFAULT_CERTIFICATE_FILE
+from conjur.constants import DEFAULT_CONFIG_FILE, DEFAULT_CERTIFICATE_FILE, DEFAULT_NETRC_FILE
 from test.util.models.configfile import ConfigFile
 
 
@@ -149,19 +149,20 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
         assert os.path.isfile(DEFAULT_CERTIFICATE_FILE)
 
     '''
-    Validates that if a user adds the use-netrc flag it is reflected in conjurrc
+    Validates that if a user adds the --force-netrc flag it is reflected in conjurrc
     '''
 
     @integration_test(True)
     @patch('builtins.input', return_value='yes')
-    def test_https_conjurrc_is_created_with_use_netrc_parameter_given(self, mock_input):
+    def test_https_conjurrc_is_created_with_force_netrc_parameter_given(self, mock_input):
         self.setup_cli_params({})
         self.invoke_cli(self.cli_auth_params,
-                        ['init', '--url', self.client_params.hostname, '--account', 'someaccount', '--self-signed', '--use-netrc'])
+                        ['init', '--url', self.client_params.hostname, '--account', 'someaccount', '--self-signed', 
+                        '--force-netrc'])
 
         utils.verify_conjurrc_contents('someaccount', self.client_params.hostname,
                                        self.environment.path_provider.certificate_path,
-                                       use_netrc='true')
+                                       netrc_path=DEFAULT_NETRC_FILE)
         assert os.path.isfile(DEFAULT_CERTIFICATE_FILE)
 
     '''

--- a/test/test_integration_credentials_netrc.py
+++ b/test/test_integration_credentials_netrc.py
@@ -22,7 +22,7 @@ from conjur.constants import DEFAULT_NETRC_FILE, DEFAULT_CONFIG_FILE, DEFAULT_CE
 
 """
 All tests require that the Keyring on the system's environment is not accessible.
-Alternatively the use_netrc flag can be set to True in the conjurrc file.
+Alternatively the netrc_path key can be set to a valid path in the conjurrc file.
 This is required to validate that the CLI operates as expected under such conditions.
 """
 @patch('conjur.wrapper.keystore_wrapper.KeystoreWrapper.is_keyring_accessible', return_value=False)
@@ -66,11 +66,11 @@ class CliIntegrationTestCredentialsNetrc(IntegrationTestCaseBase):
         self.assertEquals(type(cred_store), type(FileCredentialsProvider()))
 
     '''
-    Validate the correct CredentialStore selected when use_netrc=True is
+    Validate the correct CredentialStore selected when a netrc_path value is
     loaded from the conjurrc config file.
     '''
     @integration_test()
-    @patch('conjur.util.util_functions.get_netrc_flag_from_conjurrc', return_value=True)
+    @patch('conjur.util.util_functions.get_netrc_path_from_conjurrc', return_value="some/path/to/netrc")
     def test_provider_can_return_file_provider_keyring_with_conjurrc_config(self, keystore_disable_mock, netrc_enable_mock):
         # override the is_keychain_accessible mock for this test
         keystore_disable_mock.return_value = True
@@ -78,13 +78,13 @@ class CliIntegrationTestCredentialsNetrc(IntegrationTestCaseBase):
         self.assertEquals(type(cred_store), type(FileCredentialsProvider()))
 
     '''
-    Validate the correct CredentialStore selected when use_netrc is passed as a CLI argument.
+    Validate the correct CredentialStore selected when --force-netrc is passed as a CLI argument.
     '''
     @integration_test()
-    def test_provider_can_return_file_provider_keyring_with_use_netrc_flag(self, keystore_disable_mock):
+    def test_provider_can_return_file_provider_keyring_with_force_netrc_flag(self, keystore_disable_mock):
         # override the is_keychain_accessible mock for this test
         keystore_disable_mock.return_value = True
-        cred_store = utils.create_cred_store(use_netrc_flag=True)
+        cred_store = utils.create_cred_store(force_netrc_flag=True)
         self.assertEquals(type(cred_store), type(FileCredentialsProvider()))
 
     '''

--- a/test/test_unit_cli.py
+++ b/test/test_unit_cli.py
@@ -292,7 +292,7 @@ Copyright (c) {time.strftime("%Y")} CyberArk Software Ltd. All rights reserved.
             cert_file=None,
             authn_type="ldap",
             service_id="some-service-id",
-            use_netrc=None,
+            netrc_path=None,
         )
         mock_load.assert_called_once()
 
@@ -349,7 +349,7 @@ Copyright (c) {time.strftime("%Y")} CyberArk Software Ltd. All rights reserved.
         mock_obj.is_self_signed = False
         mock_obj.authn_type = 'authn'
         mock_obj.service_id = 'service_id'
-        mock_obj.use_netrc = None
+        mock_obj.force_netrc = None
 
         Cli().run_action('init', mock_obj)
         mock_handle_init.assert_called_once_with('https://someurl', 'somename', 'authn', 'service_id',

--- a/test/test_unit_conjurrc_data.py
+++ b/test/test_unit_conjurrc_data.py
@@ -9,27 +9,24 @@ class ConjurrcDataTest(unittest.TestCase):
     def test_conjurrc_object_representation(self):
         conjurrc_data = ConjurrcData("https://someurl", "someaccount", "/some/cert/path")
         rep_obj = conjurrc_data.__repr__()
-        expected_rep_obj = {'conjur_url': 'https://someurl', 'conjur_account': 'someaccount', 'cert_file': "/some/cert/path", 'authn_type': AuthnTypes.AUTHN, 'service_id': None, 'use_netrc': None}
+        expected_rep_obj = {'conjur_url': 'https://someurl', 'conjur_account': 'someaccount', 'cert_file': "/some/cert/path", 'authn_type': AuthnTypes.AUTHN, 'service_id': None, 'netrc_path' : None}
         self.assertEquals(str(expected_rep_obj), rep_obj)
 
-    input_dict = {'appliance_url': 'https://someurl', 'account': 'someacc', 'cert_file': '/some/path/to/pem'}
-    @patch('yaml.load', return_value=input_dict)
-    def test_conjurrc_object_is_filled_correctly(self, mock_yaml_load):
+    def test_conjurrc_object_is_filled_correctly(self):
         read_data = \
 """
 ---
 account: someacc
 appliance_url: https://someurl
 cert_file: /some/path/to/pem
+netrc_path: /some/path/to/netrc
 """
-        expected_dict = {'conjur_url': 'https://someurl', 'conjur_account': 'someacc', 'cert_file': '/some/path/to/pem', 'authn_type': AuthnTypes.AUTHN, 'service_id': None, 'use_netrc': None}
+        expected_dict = {'conjur_url': 'https://someurl', 'conjur_account': 'someacc', 'cert_file': '/some/path/to/pem', 'authn_type': AuthnTypes.AUTHN, 'service_id': None, 'netrc_path' : '/some/path/to/netrc'}
         with patch("builtins.open", mock_open(read_data=read_data)):
             mock_conjurrc_data = ConjurrcData.load_from_file()
             self.assertEquals(mock_conjurrc_data.__dict__, expected_dict)
 
-    input_dict = {'conjur_url': 'https://someurl', 'conjur_account': 'someacc', 'cert_file': '/some/path/to/pem'}
-    @patch('yaml.load', return_value=input_dict)
-    def test_conjurrc_accepts_alternative_keynames(self, mock_yaml_load):
+    def test_conjurrc_accepts_alternative_keynames(self):
         read_data = \
 """
 ---
@@ -37,7 +34,7 @@ conjur_account: someacc
 conjur_url: https://someurl
 cert_file: /some/path/to/pem
 """
-        expected_dict = {'conjur_url': 'https://someurl', 'conjur_account': 'someacc', 'cert_file': '/some/path/to/pem', 'authn_type': AuthnTypes.AUTHN, 'service_id': None, 'use_netrc': None}
+        expected_dict = {'conjur_url': 'https://someurl', 'conjur_account': 'someacc', 'cert_file': '/some/path/to/pem', 'authn_type': AuthnTypes.AUTHN, 'service_id': None, 'netrc_path' : None}
         with patch("builtins.open", mock_open(read_data=read_data)):
             mock_conjurrc_data = ConjurrcData.load_from_file()
             self.assertEquals(mock_conjurrc_data.__dict__, expected_dict)

--- a/test/test_unit_utils.py
+++ b/test/test_unit_utils.py
@@ -1,7 +1,7 @@
 import unittest
 
 from conjur_api.models import SslVerificationMode
-from conjur.constants import DEFAULT_CERTIFICATE_FILE
+from conjur.constants import DEFAULT_CERTIFICATE_FILE, DEFAULT_NETRC_FILE
 from conjur.util import util_functions as utils
 from conjur.data_object import ConjurrcData
 
@@ -30,14 +30,14 @@ class UserInputDataTest(unittest.TestCase):
         res = utils.get_ssl_verification_meta_data_from_conjurrc(True, data)
         self.assertEquals(res.mode, SslVerificationMode.CA_BUNDLE)
 
-    def test_get_netrc_flag_from_conjurrc_none(self):
+    def test_get_netrc_path_from_conjurrc_none(self):
         data = ConjurrcData(conjur_url="https://foo.com", account="some_account",
-                            cert_file="cert", use_netrc=None)
-        res = utils.get_netrc_flag_from_conjurrc(data)
-        self.assertEquals(res, False)
+                            cert_file="cert", netrc_path=None)
+        res = utils.get_netrc_path_from_conjurrc(data)
+        self.assertEquals(res, None)
 
-    def test_get_netrc_flag_from_conjurrc_true(self):
+    def test_get_netrc_path_from_conjurrc_true(self):
         data = ConjurrcData(conjur_url="https://foo.com", account="some_account",
-                            cert_file="cert", use_netrc=True)
-        res = utils.get_netrc_flag_from_conjurrc(data)
-        self.assertEquals(res, True)
+                            cert_file="cert", netrc_path=DEFAULT_NETRC_FILE)
+        res = utils.get_netrc_path_from_conjurrc(data)
+        self.assertEquals(res, DEFAULT_NETRC_FILE)

--- a/test/util/test_helpers.py
+++ b/test/util/test_helpers.py
@@ -58,7 +58,7 @@ def setup_cli(self):
 
 # *************** INIT ***************
 
-def verify_conjurrc_contents(account, hostname, cert, authn_type='authn', service_id=None, use_netrc=None):
+def verify_conjurrc_contents(account, hostname, cert, authn_type='authn', service_id=None, netrc_path=None):
     with open(f"{DEFAULT_CONFIG_FILE}", 'r') as conjurrc:
         lines = conjurrc.readlines()
         assert "---" in lines[0]
@@ -66,10 +66,10 @@ def verify_conjurrc_contents(account, hostname, cert, authn_type='authn', servic
         assert f"appliance_url: {hostname}" in lines[2], lines[2]
         assert f"authn_type: {authn_type}" in lines[3], lines[3]
         assert f"cert_file: {cert}" in lines[4], lines[4]
+        if netrc_path:
+            assert f"netrc_path: {netrc_path}" in lines[5], lines[5]
         if service_id:
-            assert f"service_id: {service_id}" in lines[5], lines[5]
-        if use_netrc:
-            assert f"use_netrc: {use_netrc}" in lines[6], lines[6]
+            assert f"service_id: {service_id}" in lines[6], lines[6]
 
 
 # *************** VARIABLE ***************
@@ -186,8 +186,8 @@ def enable_authn_ldap(self):
 
 # *************** CREDENTIALS ***************
 
-def create_cred_store(use_netrc_flag: bool = False):
-    cred_store = CredentialStoreFactory.create_credential_store(use_netrc_flag=use_netrc_flag)
+def create_cred_store(force_netrc_flag: bool = False):
+    cred_store = CredentialStoreFactory.create_credential_store(force_netrc_flag=force_netrc_flag)
     return cred_store
 
 


### PR DESCRIPTION
### Desired Outcome

Add flag to `conjur init` that allows you to force the CLI to store Conjur credentials in a file mode (see [native keystore spike](https://gist.github.com/gl-johnson/b3552549cb43222429505c7b9ea12a7b#conjur-cli-in-file-keystore-mode)).

### Implemented Changes

- Added an an option (`conjur init --force-netrc`) to enable netrc as the keystore to be used by the CLI
- If enabled, the option is stored in .conjurrc for future CLI commands

### Connected Issue/Story

CyberArk internal issue link: [ONYX-22954](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-22954)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
